### PR TITLE
Relies on BCR for maliput_malidrive binaries.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "maliput-sdk/maliput_malidrive"]
-	path = maliput-sdk/maliput_malidrive
-	url = https://github.com/maliput/maliput_malidrive.git
-	branch = main

--- a/maliput-sdk/BUILD.bazel
+++ b/maliput-sdk/BUILD.bazel
@@ -20,6 +20,7 @@ cc_binary(
         "@maliput//:geometry_base",
         "@maliput//:plugin",
         "@maliput//:utility",
+        "@maliput_malidrive//:maliput_plugins/libmaliput_malidrive_road_network.so",
     ],
     linkshared = True,
     linkstatic = False

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -10,3 +10,4 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "maliput", version = "1.2.0")
+bazel_dep(name = "maliput_malidrive", version = "0.2.1")

--- a/maliput-sdk/MODULE.bazel.lock
+++ b/maliput-sdk/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "52ecdcb07d692508dc330491ce2a8741a771ecd906bd994126d2180815c99246",
+  "moduleFileHash": "e886fb2ff68c2582c917f300faf3257691c5d3719ce66966f367165c716ae65b",
   "flags": {
     "cmdRegistries": [
       "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/"
@@ -27,6 +27,7 @@
       "deps": {
         "rules_cc": "rules_cc@0.0.9",
         "maliput": "maliput@1.2.0",
+        "maliput_malidrive": "maliput_malidrive@0.2.1",
         "bazel_tools": "bazel_tools@_",
         "local_config_platform": "local_config_platform@_"
       }
@@ -106,6 +107,38 @@
           ],
           "integrity": "sha256-CsvGDS3z7cAhWecLmCKLnijJrYyTJ0hKuBjzyzbnNLY=",
           "strip_prefix": "maliput-1.2.0",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "maliput_malidrive@0.2.1": {
+      "name": "maliput_malidrive",
+      "version": "0.2.1",
+      "key": "maliput_malidrive@0.2.1",
+      "repoName": "maliput_malidrive",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "rules_cc": "rules_cc@0.0.9",
+        "eigen": "eigen@3.4.0",
+        "gflags": "gflags@2.2.2",
+        "maliput": "maliput@1.2.0",
+        "tinyxml2": "tinyxml2@9.0.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "maliput_malidrive~0.2.1",
+          "urls": [
+            "https://github.com/maliput/maliput_malidrive/releases/download/0.2.1/maliput_malidrive-0.2.1.tar.gz"
+          ],
+          "integrity": "sha256-4/9SZQvPO7bjPW0xran1thHzJk8SlW1dcMN5lwGXP5Q=",
+          "strip_prefix": "maliput_malidrive-0.2.1",
           "remote_patches": {},
           "remote_patch_strip": 0
         }
@@ -344,6 +377,66 @@
             "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/yaml-cpp/0.8.0/patches/module_dot_bazel.patch": "sha256-YM6xq0Mtu51Okntj5lRQ3V04DyZNm4hZdrSDMio1KeU="
           },
           "remote_patch_strip": 1
+        }
+      }
+    },
+    "gflags@2.2.2": {
+      "name": "gflags",
+      "version": "2.2.2",
+      "key": "gflags@2.2.2",
+      "repoName": "gflags",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "gflags~2.2.2",
+          "urls": [
+            "https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz"
+          ],
+          "integrity": "sha256-NK8vFc9zZ1E7NSvc0kk6sUzkNpLS3NnfxJlJKWbGTc8=",
+          "strip_prefix": "gflags-2.2.2",
+          "remote_patches": {
+            "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/gflags/2.2.2/patches/module_dot_bazel.patch": "sha256-BVSk+8ijV+s6djcokSgSZGlP153Q+rvF2h9W/AG53Zo="
+          },
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "tinyxml2@9.0.0": {
+      "name": "tinyxml2",
+      "version": "9.0.0",
+      "key": "tinyxml2@9.0.0",
+      "repoName": "tinyxml2",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "rules_cc": "rules_cc@0.0.9",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "tinyxml2~9.0.0",
+          "urls": [
+            "https://github.com/leethomason/tinyxml2/archive/refs/tags/9.0.0.tar.gz"
+          ],
+          "integrity": "sha256-zC8UF8MIsfasxU+I63B3Ggv2X3YoLOXEDlTP5SlScCw=",
+          "strip_prefix": "tinyxml2-9.0.0",
+          "remote_patches": {
+            "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/tinyxml2/9.0.0/patches/add_build_file.patch": "sha256-5p5iDlTVSGqie/OOuyvVQ0/XpasKbr1TVVv94yQlNNk=",
+            "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/tinyxml2/9.0.0/patches/module_dot_bazel.patch": "sha256-br7DR6A3gWp74gZc0erwci1oRd1A7G922HPrbY/czVg="
+          },
+          "remote_patch_strip": 0
         }
       }
     },
@@ -734,12 +827,13 @@
               "name": "apple_support~1.5.0~apple_cc_configure_extension~local_config_apple_cc_toolchains"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
+        "bzlTransitiveDigest": "mcsWHq3xORJexV5/4eCvNOLxFOQKV6eli3fkr+tEaqE=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -757,7 +851,14 @@
               "name": "bazel_tools~cc_configure_extension~local_config_cc_toolchains"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
@@ -775,7 +876,8 @@
               "remote_xcode": ""
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
@@ -791,12 +893,13 @@
               "name": "bazel_tools~sh_configure_extension~local_config_sh"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
+        "bzlTransitiveDigest": "D02GmifxnV/IhYgspsJMDZ/aE8HxAjXgek5gi6FSto4=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -1331,7 +1434,19 @@
               "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\n"
             }
           }
-        }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java~7.1.0",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_java~7.1.0",
+            "remote_java_tools",
+            "rules_java~7.1.0~toolchains~remote_java_tools"
+          ]
+        ]
       }
     }
   }

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -54,25 +54,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     let bazel_bin_dir = bazel_output_base_dir.join("bazel-bin");
 
-
-    // TODO(francocipollone): Remove this custom build once maliput_malidrive is within BCR.
-    env::set_current_dir("maliput_malidrive")
-    .unwrap_or_else(|_| panic!("Unable to change directory to {}", "maliput_malidrive"));
-    let build_malidrive = std::process::Command::new("bazel")
-        .arg("build")
-        .arg("//...")
-        .status()
-        .expect("Failed to generate build script");
-    if build_malidrive.code() != Some(0) {
-        panic!("Failed to generate build script");
-    }
-    let maliput_malidrive_bin_path = PathBuf::from(env::current_dir().unwrap()).join("bazel-bin");
-
-    // ************* maliput header files ************* //
-
     // TODO(francocipollone): Get version from MODULE.bazel configuration.
     let maliput_version = "1.2.0";
     let maliput_bin_path = bazel_bin_dir.join("external").join(format!("maliput~{}", maliput_version));
+    let maliput_malidrive_version: &str = "0.2.1";
+    let maliput_malidrive_bin_path = bazel_bin_dir.join("external").join(format!("maliput_malidrive~{}", maliput_malidrive_version));
+
+    // ************* maliput header files ************* //
 
     //---Header files---
     let virtual_includes_path = maliput_bin_path.join("_virtual_includes");
@@ -106,9 +94,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:maliput_malidrive_bin_path={}", maliput_malidrive_bin_path.display()); //> Accessed as MALIPUT_SDK_MALIPUT_MALIDRIVE_BIN_PATH
     println!("cargo:maliput_malidrive_plugin_path={}",
         maliput_malidrive_bin_path
-        .join("maliput_plugins")
-        .join("libmaliput_malidrive_road_network.so.runfiles")
-        .join("_main")
         .join("maliput_plugins")
         .display()); //> Accessed as MALIPUT_SDK_MALIPUT_MALIDRIVE_PLUGIN_PATH
 


### PR DESCRIPTION
# 🎉 New feature

Closes #8 

## Requisites
 - [ ] We need maliput_malidrive 0.2.1 release: https://github.com/bazelbuild/bazel-central-registry/pull/1423

## Summary
 - Relies on maliput_malidrive in BCR -> 0.2.1 version

## Test it
```
cargo run --example create_rn
```
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
