### PR TITLE
Adds bindings to maliput::math::Vector3.

### DIFF
--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -36,6 +36,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/create_road_network_wrapper.h");
+    println!("cargo:rerun-if-changed=src/math/math.h");
+    println!("cargo:rerun-if-changed=src/math/mod.rs");
 
     let maliput_bin_path = PathBuf::from(env::var("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH").expect("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH not set"));
 
@@ -43,16 +45,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Link to all the libraries in the bazel-bin folder.
     // The order of these is important! Otherwise, we get undefined reference errors.
+    println!("cargo:rustc-link-lib=math");
+    println!("cargo:rustc-link-lib=common");
     println!("cargo:rustc-link-lib=drake");
     println!("cargo:rustc-link-lib=geometry_base");
     println!("cargo:rustc-link-lib=plugin");
-    println!("cargo:rustc-link-lib=common");
     println!("cargo:rustc-link-lib=utility");
-    println!("cargo:rustc-link-lib=math");
     println!("cargo:rustc-link-lib=base");
     println!("cargo:rustc-link-lib=api");
 
-    cxx_build::bridges(["src/api.rs", "src/plugin.rs"])
+    cxx_build::bridges(["src/api.rs", "src/math/mod.rs", "src/plugin.rs"])
         .flag_if_supported("-std=c++17")
         .include("src")
         .compile("maliput-sys");

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -28,6 +28,52 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod api;
-pub mod math;
-pub mod plugin;
+#pragma once
+
+#include <memory>
+
+#include "maliput/math/vector.h"
+
+#include <rust/cxx.h>
+
+namespace maliput {
+namespace math {
+
+/// Creates a new maliput::math::Vector3.
+/// Forwads to maliput::math::Vector3(double x, double y, double z) constructor.
+std::unique_ptr<Vector3> Vector3_new(rust::f64 x, rust::f64 y, rust::f64 z) {
+  return std::make_unique<Vector3>(x, y, z);
+}
+
+/// Returns the norm of the vector.
+/// Forwards to maliput::math::Vector3::norm() method.
+double Vector3_norm(const Vector3& self) {
+  return self.norm();
+}
+
+/// Returns the dot product of two vectors.
+/// Forwards to maliput::math::Vector3::dot(const Vector3& other) method.
+double Vector3_dot(const Vector3& self, const Vector3& other) {
+  return self.dot(other);
+}
+
+/// Returns the cross product of two vectors.
+/// Forwards to maliput::math::Vector3::cross(const Vector3& other) method.
+std::unique_ptr<Vector3> Vector3_cross(const Vector3& self, const Vector3& other) {
+  return std::make_unique<Vector3>(self.cross(other));
+}
+
+/// Returns true if the two vectors are equal.
+/// Forwards to maliput::math::Vector3::operator==(const Vector3& other) method.
+bool Vector3_equals(const Vector3& self, const Vector3& other) {
+  return self == other;
+}
+
+/// Returns the string representation of the vector.
+/// Forwards to maliput::math::Vector3::to_str() method.
+rust::string Vector3_to_str(const Vector3& self) {
+  return self.to_str();
+}
+
+} // namespace math
+}  // namespace maliput

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -32,12 +32,29 @@
 
 #include <memory>
 
-#include "maliput/math/vector.h"
+#include <maliput/math/vector.h>
 
 #include <rust/cxx.h>
 
 namespace maliput {
 namespace math {
+
+// Note
+// Primitives types are aliased at rust/cxx header file.
+// See https://github.com/dtolnay/cxx/blob/131fbc4a14c154a998eb9fc83b9dbb82a521fb1c/include/cxx.h#L455-L465
+// @{
+// using u8 = std::uint8_t;
+// using u16 = std::uint16_t;
+// using u32 = std::uint32_t;
+// using u64 = std::uint64_t;
+// using usize = std::size_t;
+// using i8 = std::int8_t;
+// using i16 = std::int16_t;
+// using i32 = std::int32_t;
+// using i64 = std::int64_t;
+// using f32 = float;
+// using f64 = double;
+// }@
 
 /// Creates a new maliput::math::Vector3.
 /// Forwads to maliput::math::Vector3(double x, double y, double z) constructor.
@@ -47,13 +64,13 @@ std::unique_ptr<Vector3> Vector3_new(rust::f64 x, rust::f64 y, rust::f64 z) {
 
 /// Returns the norm of the vector.
 /// Forwards to maliput::math::Vector3::norm() method.
-double Vector3_norm(const Vector3& self) {
+rust::f64 Vector3_norm(const Vector3& self) {
   return self.norm();
 }
 
 /// Returns the dot product of two vectors.
 /// Forwards to maliput::math::Vector3::dot(const Vector3& other) method.
-double Vector3_dot(const Vector3& self, const Vector3& other) {
+rust::f64 Vector3_dot(const Vector3& self, const Vector3& other) {
   return self.dot(other);
 }
 
@@ -71,8 +88,8 @@ bool Vector3_equals(const Vector3& self, const Vector3& other) {
 
 /// Returns the string representation of the vector.
 /// Forwards to maliput::math::Vector3::to_str() method.
-rust::string Vector3_to_str(const Vector3& self) {
-  return self.to_str();
+rust::String Vector3_to_str(const Vector3& self) {
+  return {self.to_str()};
 }
 
 } // namespace math

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -28,6 +28,24 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod api;
-pub mod math;
-pub mod plugin;
+#[cxx::bridge(namespace = "maliput::math")]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("maliput/math/vector.h");
+        include!("math/math.h");
+
+        #[namespace = "maliput::math"]
+        type Vector3;
+        fn Vector3_new(x: f64, y: f64, z: f64) -> UniquePtr<Vector3>;
+        fn x(self: &Vector3) -> f64;
+        fn y(self: &Vector3) -> f64;
+        fn z(self: &Vector3) -> f64;
+
+        fn Vector3_norm(v: &Vector3) -> f64;
+        fn Vector3_dot(v: &Vector3, w: &Vector3) -> f64;
+        fn Vector3_cross(v: &Vector3, w: &Vector3) -> UniquePtr<Vector3>;
+
+        fn Vector3_equals(v: &Vector3, w: &Vector3) -> bool;
+        fn Vector3_to_str(v: &Vector3) -> String;
+    }
+}

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -31,7 +31,6 @@
 #[cxx::bridge(namespace = "maliput::math")]
 pub mod ffi {
     unsafe extern "C++" {
-        include!("maliput/math/vector.h");
         include!("math/math.h");
 
         #[namespace = "maliput::math"]

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -28,6 +28,51 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub mod api;
-pub mod math;
-pub mod plugin;
+#[cfg(test)]
+mod math_test {
+    use maliput_sys::math::ffi::Vector3_new;
+
+    use maliput_sys::math::ffi::Vector3_cross;
+    use maliput_sys::math::ffi::Vector3_dot;
+    use maliput_sys::math::ffi::Vector3_norm;
+    use maliput_sys::math::ffi::Vector3_equals;
+
+    #[test]
+    fn vector3_new() {
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        assert_eq!(v.x(), 1.0);
+        assert_eq!(v.y(), 2.0);
+        assert_eq!(v.z(), 3.0);
+    }
+
+    #[test]
+    fn vector3_norm() {
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        assert_eq!(Vector3_norm(&v), (v.x()*v.x() + v.y()*v.y() + v.z()*v.z()).sqrt());
+    }
+
+    #[test]
+    fn vector3_dot() {
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        let w = Vector3_new(4.0, 5.0, 6.0);
+        assert_eq!(Vector3_dot(&v, &w), v.x()*w.x() + v.y()*w.y() + v.z()*w.z());
+    }
+
+    #[test]
+    fn vector3_cross() {
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        let w = Vector3_new(4.0, 5.0, 6.0);
+        let cross = Vector3_cross(&v, &w);
+        assert_eq!(cross.x(), v.y()*w.z() - v.z()*w.y());
+        assert_eq!(cross.y(), v.z()*w.x() - v.x()*w.z());
+        assert_eq!(cross.z(), v.x()*w.y() - v.y()*w.x());
+    }
+
+    #[test]
+    fn vector3_equals() {
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        let w = Vector3_new(1.0, 2.0, 3.0);
+        assert!(Vector3_equals(&v, &w));
+    }
+
+}


### PR DESCRIPTION
# 🎉 New feature

Related to #11 

## Summary
 - Adds bindings to maliput::math::Vector3
 - Info:
    - https://cxx.rs/tutorial.html#calling-a-c-function-from-rust

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
