### PR TITLE
Updates submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "maliput-sdk/maliput_malidrive"]
 	path = maliput-sdk/maliput_malidrive
-	url = https://github.com/francocipollone/maliput_malidrive.git
-	branch = francocipollone/rust_bazel_plugin_lib
+	url = https://github.com/maliput/maliput_malidrive.git
+	branch = main


### PR DESCRIPTION
# Bug fix

## Summary
We can now rely on maliput_malidrive oficial repo.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
