### PR TITLE
Adds Vector3, Matrix3, Quaternion, RollPitchYaw and api::Rotation bindings

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -121,5 +121,37 @@ std::unique_ptr<RoadPositionResult> RoadGeometry_ToRoadPosition(const RoadGeomet
   return std::make_unique<RoadPositionResult>(road_geometry.ToRoadPosition(inertial_pos));
 }
 
+std::unique_ptr<Rotation> Rotation_new() {
+  return std::make_unique<Rotation>();
+}
+
+std::unique_ptr<Rotation> Rotation_from_quat(const maliput::math::Quaternion& q) {
+  return std::make_unique<Rotation>(Rotation::FromQuat(q));
+}
+
+std::unique_ptr<Rotation> Rotation_from_rpy(const maliput::math::RollPitchYaw& rpy) {
+  return std::make_unique<Rotation>(Rotation::FromRpy(rpy.vector()));
+}
+
+void Rotation_set_quat(Rotation& rotation, const maliput::math::Quaternion& q) {
+  rotation.set_quat(q);
+}
+
+std::unique_ptr<maliput::math::RollPitchYaw> Rotation_rpy(const Rotation& rotation) {
+  return std::make_unique<maliput::math::RollPitchYaw>(rotation.rpy());
+}
+
+std::unique_ptr<maliput::math::Matrix3> Rotation_matrix(const Rotation& rotation) {
+  return std::make_unique<maliput::math::Matrix3>(rotation.matrix());
+}
+
+std::unique_ptr<InertialPosition> Rotation_Apply(const Rotation& rotation, const InertialPosition& inertial_pos) {
+  return std::make_unique<InertialPosition>(rotation.Apply(inertial_pos));
+}
+
+std::unique_ptr<Rotation> Rotation_Reverse(const Rotation& rotation) {
+  return std::make_unique<Rotation>(rotation.Reverse());
+}
+
 } // namespace api
 } // namespace maliput

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -35,6 +35,12 @@ pub mod ffi {
 
         #[namespace = "maliput::math"]
         type Vector3 = crate::math::ffi::Vector3;
+        #[namespace = "maliput::math"]
+        type Quaternion = crate::math::ffi::Quaternion;
+        #[namespace = "maliput::math"]
+        type Matrix3 = crate::math::ffi::Matrix3;
+        #[namespace = "maliput::math"]
+        type RollPitchYaw = crate::math::ffi::RollPitchYaw;
 
         #[namespace = "maliput::api"]
         type RoadNetwork;
@@ -105,6 +111,23 @@ pub mod ffi {
         fn RoadPositionResult_road_position(result: &RoadPositionResult) -> UniquePtr<RoadPosition>;
         fn RoadPositionResult_nearest_position(result: &RoadPositionResult) -> UniquePtr<InertialPosition>;
         fn RoadPositionResult_distance(result: &RoadPositionResult) -> f64;
+
+        // Rotation bindings definitions
+        type Rotation;
+        fn Rotation_new() -> UniquePtr<Rotation>;
+        fn Rotation_from_quat(q: &Quaternion) -> UniquePtr<Rotation>;
+        fn Rotation_from_rpy(rpy: &RollPitchYaw) -> UniquePtr<Rotation>;
+        fn roll(self: &Rotation) -> f64;
+        fn pitch(self: &Rotation) -> f64;
+        fn yaw(self: &Rotation) -> f64;
+        fn quat(self: &Rotation) -> &Quaternion;
+        fn Distance(self: &Rotation, other: &Rotation) -> f64;
+        fn Rotation_set_quat(r: Pin<&mut Rotation>, q: &Quaternion);
+        fn Rotation_rpy(r: &Rotation) -> UniquePtr<RollPitchYaw>;
+        fn Rotation_matrix(r: &Rotation) -> UniquePtr<Matrix3>;
+        fn Rotation_Apply(r: &Rotation, ip: &InertialPosition) -> UniquePtr<InertialPosition>;
+        fn Rotation_Reverse(r: &Rotation) -> UniquePtr<Rotation>;
+
     }
     impl UniquePtr<RoadNetwork> {}
     impl UniquePtr<LanePosition> {}

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -33,6 +33,7 @@
 #include <memory>
 
 #include <maliput/math/vector.h>
+#include <maliput/math/matrix.h>
 
 #include <rust/cxx.h>
 
@@ -101,6 +102,60 @@ bool Vector4_equals(const Vector4& self, const Vector4& other) {
 }
 
 rust::String Vector4_to_str(const Vector4& self) {
+  return {self.to_str()};
+}
+
+std::unique_ptr<Matrix3> Matrix3_new(double m00, double m01, double m02,
+                                     double m10, double m11, double m12,
+                                     double m20, double m21, double m22) {
+  return std::make_unique<Matrix3>(std::initializer_list<double>{m00, m01, m02, m10, m11, m12, m20, m21, m22});
+}
+
+std::unique_ptr<Vector3> Matrix3_row(const Matrix3& self, rust::usize index) {
+  return std::make_unique<Vector3>(self.row(index));
+}
+
+std::unique_ptr<Vector3> Matrix3_col(const Matrix3& self, rust::usize index) {
+  return std::make_unique<Vector3>(self.col(index));
+}
+
+std::unique_ptr<Matrix3> Matrix3_cofactor_matrix(const Matrix3& self) {
+  return std::make_unique<Matrix3>(self.cofactor());
+}
+
+std::unique_ptr<Matrix3> Matrix3_transpose(const Matrix3& self) {
+  return std::make_unique<Matrix3>(self.transpose());
+}
+
+std::unique_ptr<Matrix3> Matrix3_adjoint(const Matrix3& self) {
+  return std::make_unique<Matrix3>(self.adjoint());
+}
+
+std::unique_ptr<Matrix3> Matrix3_inverse(const Matrix3& self) {
+  return std::make_unique<Matrix3>(self.inverse());
+}
+
+bool Matrix3_equals(const Matrix3& self, const Matrix3& other) {
+  return self == other;
+}
+
+std::unique_ptr<Matrix3> Matrix3_operator_mul(const Matrix3& self, const Matrix3& other) {
+  return std::make_unique<Matrix3>(self * other);
+}
+
+std::unique_ptr<Matrix3> Matrix3_operator_sum(const Matrix3& self, const Matrix3& other) {
+  return std::make_unique<Matrix3>(self + other);
+}
+
+std::unique_ptr<Matrix3> Matrix3_operator_sub(const Matrix3& self, const Matrix3& other) {
+  return std::make_unique<Matrix3>(self - other);
+}
+
+std::unique_ptr<Matrix3> Matrix3_operator_divide_by_scalar(const Matrix3& self, rust::f64 scalar) {
+  return std::make_unique<Matrix3>(self / scalar);
+}
+
+rust::String Matrix3_to_str(const Matrix3& self) {
   return {self.to_str()};
 }
 

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -31,9 +31,11 @@
 #pragma once
 
 #include <memory>
+#include <sstream>
 
 #include <maliput/math/vector.h>
 #include <maliput/math/matrix.h>
+#include <maliput/math/quaternion.h>
 
 #include <rust/cxx.h>
 
@@ -157,6 +159,48 @@ std::unique_ptr<Matrix3> Matrix3_operator_divide_by_scalar(const Matrix3& self, 
 
 rust::String Matrix3_to_str(const Matrix3& self) {
   return {self.to_str()};
+}
+
+std::unique_ptr<Quaternion> Quaternion_new(rust::f64 w, rust::f64 x, rust::f64 y, rust::f64 z) {
+  return std::make_unique<Quaternion>(w, x, y, z);
+}
+
+std::unique_ptr<Vector3> Quaternion_vec(const Quaternion& self) {
+  return std::make_unique<Vector3>(self.vec());
+}
+
+std::unique_ptr<Vector4> Quaternion_coeffs(const Quaternion& self) {
+  return std::make_unique<Vector4>(self.coeffs());
+}
+
+std::unique_ptr<Quaternion> Quaternion_Inverse(const Quaternion& self) {
+  return std::make_unique<Quaternion>(self.Inverse());
+}
+
+std::unique_ptr<Quaternion> Quaternion_conjugate(const Quaternion& self) {
+  return std::make_unique<Quaternion>(self.conjugate());
+}
+
+std::unique_ptr<Matrix3> Quaternion_ToRotationMatrix(const Quaternion& self) {
+  return std::make_unique<Matrix3>(self.ToRotationMatrix());
+}
+
+std::unique_ptr<Vector3> Quaternion_TransformVector(const Quaternion& self, const Vector3& vec) {
+  return std::make_unique<Vector3>(self.TransformVector(vec));
+}
+
+bool Quaternion_IsApprox(const Quaternion& self, const Quaternion& other, rust::f64 precision) {
+  return self.IsApprox(other, precision);
+}
+
+bool Quaternion_equals(const Quaternion& self, const Quaternion& other) {
+  return self == other;
+}
+
+rust::String Quaternion_to_str(const Quaternion& self) {
+  std::stringstream ss;
+  ss << self;
+  return {ss.str()};
 }
 
 } // namespace math

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include <sstream>
 

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -36,6 +36,7 @@
 #include <maliput/math/vector.h>
 #include <maliput/math/matrix.h>
 #include <maliput/math/quaternion.h>
+#include <maliput/math/roll_pitch_yaw.h>
 
 #include <rust/cxx.h>
 
@@ -201,6 +202,30 @@ rust::String Quaternion_to_str(const Quaternion& self) {
   std::stringstream ss;
   ss << self;
   return {ss.str()};
+}
+
+std::unique_ptr<RollPitchYaw> RollPitchYaw_new(rust::f64 roll, rust::f64 pitch, rust::f64 yaw) {
+  return std::make_unique<RollPitchYaw>(roll, pitch, yaw);
+}
+
+void RollPitchYaw_set(RollPitchYaw& self, rust::f64 roll, rust::f64 pitch, rust::f64 yaw) {
+  self.set(roll, pitch, yaw);
+}
+
+void RollPitchYaw_SetFromQuaternion(RollPitchYaw& self, const Quaternion& q) {
+  self.SetFromQuaternion(q);
+}
+
+std::unique_ptr<Quaternion> RollPitchYaw_ToQuaternion(const RollPitchYaw& self) {
+  return std::make_unique<Quaternion>(self.ToQuaternion());
+}
+
+std::unique_ptr<Matrix3> RollPitchYaw_ToMatrix(const RollPitchYaw& self) {
+  return std::make_unique<Matrix3>(self.ToMatrix());
+}
+
+std::unique_ptr<Matrix3> RollPitchYaw_CalcRotationMatrixDt(const RollPitchYaw& self, const Vector3& w) {
+  return std::make_unique<Matrix3>(self.CalcRotationMatrixDt(w));
 }
 
 } // namespace math

--- a/maliput-sys/src/math/math.h
+++ b/maliput-sys/src/math/math.h
@@ -62,12 +62,6 @@ std::unique_ptr<Vector3> Vector3_new(rust::f64 x, rust::f64 y, rust::f64 z) {
   return std::make_unique<Vector3>(x, y, z);
 }
 
-/// Returns the norm of the vector.
-/// Forwards to maliput::math::Vector3::norm() method.
-rust::f64 Vector3_norm(const Vector3& self) {
-  return self.norm();
-}
-
 /// Returns the dot product of two vectors.
 /// Forwards to maliput::math::Vector3::dot(const Vector3& other) method.
 rust::f64 Vector3_dot(const Vector3& self, const Vector3& other) {
@@ -89,6 +83,24 @@ bool Vector3_equals(const Vector3& self, const Vector3& other) {
 /// Returns the string representation of the vector.
 /// Forwards to maliput::math::Vector3::to_str() method.
 rust::String Vector3_to_str(const Vector3& self) {
+  return {self.to_str()};
+}
+
+/// Creates a new maliput::math::Vector4.
+/// Forwads to maliput::math::Vector4(double x, double y, double z, double w) constructor.
+std::unique_ptr<Vector4> Vector4_new(rust::f64 x, rust::f64 y, rust::f64 z, rust::f64 w) {
+  return std::make_unique<Vector4>(x, y, z, w);
+}
+
+rust::f64 Vector4_dot(const Vector4& self, const Vector4& other) {
+  return self.dot(other);
+}
+
+bool Vector4_equals(const Vector4& self, const Vector4& other) {
+  return self == other;
+}
+
+rust::String Vector4_to_str(const Vector4& self) {
   return {self.to_str()};
 }
 

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -86,5 +86,26 @@ pub mod ffi {
         fn Matrix3_operator_sub(m: &Matrix3, other: &Matrix3) -> UniquePtr<Matrix3>;
         fn Matrix3_operator_divide_by_scalar(m: &Matrix3, scalar: f64) -> UniquePtr<Matrix3>;
         fn Matrix3_to_str(m: &Matrix3) -> String;
+
+        type Quaternion;
+        fn Quaternion_new(w: f64, x: f64, y: f64, z: f64) -> UniquePtr<Quaternion>;
+        fn w(self: &Quaternion) -> f64;
+        fn x(self: &Quaternion) -> f64;
+        fn y(self: &Quaternion) -> f64;
+        fn z(self: &Quaternion) -> f64;
+        fn dot(self: &Quaternion, other: &Quaternion) -> f64;
+        fn AngularDistance(self: &Quaternion, other: &Quaternion) -> f64;
+        fn norm(self: &Quaternion) -> f64;
+        fn normalize(self: Pin<&mut Quaternion>);
+        fn squared_norm(self: &Quaternion) -> f64;
+        fn Quaternion_vec(q: &Quaternion) -> UniquePtr<Vector3>;
+        fn Quaternion_coeffs(q: &Quaternion) -> UniquePtr<Vector4>;
+        fn Quaternion_Inverse(q: &Quaternion) -> UniquePtr<Quaternion>;
+        fn Quaternion_conjugate(q: &Quaternion) -> UniquePtr<Quaternion>;
+        fn Quaternion_ToRotationMatrix(q: &Quaternion) -> UniquePtr<Matrix3>;
+        fn Quaternion_TransformVector(q: &Quaternion, v: &Vector3) -> UniquePtr<Vector3>;
+        fn Quaternion_IsApprox(q: &Quaternion, other: &Quaternion, precision: f64) -> bool;
+        fn Quaternion_equals(q: &Quaternion, other: &Quaternion) -> bool;
+        fn Quaternion_to_str(q: &Quaternion) -> String;
     }
 }

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -57,5 +57,34 @@ pub mod ffi {
         fn Vector4_dot(v: &Vector4, w: &Vector4) -> f64;
         fn Vector4_equals(v: &Vector4, w: &Vector4) -> bool;
         fn Vector4_to_str(v: &Vector4) -> String;
+
+        type Matrix3;
+        #[allow(clippy::too_many_arguments)]
+        fn Matrix3_new(
+            m00: f64,
+            m01: f64,
+            m02: f64,
+            m10: f64,
+            m11: f64,
+            m12: f64,
+            m20: f64,
+            m21: f64,
+            m22: f64,
+        ) -> UniquePtr<Matrix3>;
+        fn cofactor(self: &Matrix3, row: u64, col: u64) -> f64;
+        fn determinant(self: &Matrix3) -> f64;
+        fn is_singular(self: &Matrix3) -> bool;
+        fn Matrix3_row(m: &Matrix3, index: u64) -> UniquePtr<Vector3>;
+        fn Matrix3_col(m: &Matrix3, index: u64) -> UniquePtr<Vector3>;
+        fn Matrix3_cofactor_matrix(m: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_transpose(m: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_equals(m: &Matrix3, other: &Matrix3) -> bool;
+        fn Matrix3_adjoint(m: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_operator_mul(m: &Matrix3, other: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_inverse(m: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_operator_sum(m: &Matrix3, other: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_operator_sub(m: &Matrix3, other: &Matrix3) -> UniquePtr<Matrix3>;
+        fn Matrix3_operator_divide_by_scalar(m: &Matrix3, scalar: f64) -> UniquePtr<Matrix3>;
+        fn Matrix3_to_str(m: &Matrix3) -> String;
     }
 }

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -39,12 +39,23 @@ pub mod ffi {
         fn x(self: &Vector3) -> f64;
         fn y(self: &Vector3) -> f64;
         fn z(self: &Vector3) -> f64;
-
-        fn Vector3_norm(v: &Vector3) -> f64;
+        fn norm(self: &Vector3) -> f64;
+        fn normalize(self: Pin<&mut Vector3>);
         fn Vector3_dot(v: &Vector3, w: &Vector3) -> f64;
         fn Vector3_cross(v: &Vector3, w: &Vector3) -> UniquePtr<Vector3>;
-
         fn Vector3_equals(v: &Vector3, w: &Vector3) -> bool;
         fn Vector3_to_str(v: &Vector3) -> String;
+
+        type Vector4;
+        fn Vector4_new(x: f64, y: f64, z: f64, w: f64) -> UniquePtr<Vector4>;
+        fn x(self: &Vector4) -> f64;
+        fn y(self: &Vector4) -> f64;
+        fn z(self: &Vector4) -> f64;
+        fn w(self: &Vector4) -> f64;
+        fn norm(self: &Vector4) -> f64;
+        fn normalize(self: Pin<&mut Vector4>);
+        fn Vector4_dot(v: &Vector4, w: &Vector4) -> f64;
+        fn Vector4_equals(v: &Vector4, w: &Vector4) -> bool;
+        fn Vector4_to_str(v: &Vector4) -> String;
     }
 }

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -107,5 +107,17 @@ pub mod ffi {
         fn Quaternion_IsApprox(q: &Quaternion, other: &Quaternion, precision: f64) -> bool;
         fn Quaternion_equals(q: &Quaternion, other: &Quaternion) -> bool;
         fn Quaternion_to_str(q: &Quaternion) -> String;
+
+        type RollPitchYaw;
+        fn RollPitchYaw_new(roll: f64, pitch: f64, yaw: f64) -> UniquePtr<RollPitchYaw>;
+        fn roll_angle(self: &RollPitchYaw) -> f64;
+        fn pitch_angle(self: &RollPitchYaw) -> f64;
+        fn yaw_angle(self: &RollPitchYaw) -> f64;
+        fn vector(self: &RollPitchYaw) -> &Vector3;
+        fn RollPitchYaw_set(rpy: Pin<&mut RollPitchYaw>, roll: f64, pitch: f64, yaw: f64);
+        fn RollPitchYaw_SetFromQuaternion(rpy: Pin<&mut RollPitchYaw>, q: &Quaternion);
+        fn RollPitchYaw_ToQuaternion(rpy: &RollPitchYaw) -> UniquePtr<Quaternion>;
+        fn RollPitchYaw_ToMatrix(rpy: &RollPitchYaw) -> UniquePtr<Matrix3>;
+        fn RollPitchYaw_CalcRotationMatrixDt(rpy: &RollPitchYaw, rpyDt: &Vector3) -> UniquePtr<Matrix3>;
     }
 }

--- a/maliput-sys/tests/api_tests.rs
+++ b/maliput-sys/tests/api_tests.rs
@@ -35,7 +35,6 @@ mod api_test {
         use maliput_sys::api::ffi::LanePosition_to_str;
 
         use maliput_sys::math::ffi::Vector3_new;
-        use maliput_sys::math::ffi::Vector3_norm;
 
         #[test]
         fn laneposition_new() {
@@ -48,7 +47,7 @@ mod api_test {
         #[test]
         fn srh() {
             let lane_pos = LanePosition_new(1.0, 2.0, 3.0);
-            assert_eq!(Vector3_norm(lane_pos.srh()), 3.7416573867739413);
+            assert_eq!(lane_pos.srh().norm(), 3.7416573867739413);
         }
 
         #[test]

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -53,6 +53,13 @@ mod math_test {
     use maliput_sys::math::ffi::Matrix3_to_str;
     use maliput_sys::math::ffi::Matrix3_transpose;
 
+    use maliput_sys::math::ffi::RollPitchYaw_CalcRotationMatrixDt;
+    use maliput_sys::math::ffi::RollPitchYaw_SetFromQuaternion;
+    use maliput_sys::math::ffi::RollPitchYaw_ToMatrix;
+    use maliput_sys::math::ffi::RollPitchYaw_ToQuaternion;
+    use maliput_sys::math::ffi::RollPitchYaw_new;
+    use maliput_sys::math::ffi::RollPitchYaw_set;
+
     use maliput_sys::math::ffi::Quaternion_Inverse;
     use maliput_sys::math::ffi::Quaternion_IsApprox;
     use maliput_sys::math::ffi::Quaternion_ToRotationMatrix;
@@ -425,5 +432,70 @@ mod math_test {
     fn quaternion_to_str() {
         let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
         assert_eq!(Quaternion_to_str(&q), "(w: 1, x: 2, y: 3, z: 4)");
+    }
+
+    #[test]
+    fn roll_pitch_yaw_new() {
+        let rpy = RollPitchYaw_new(1.0, 2.0, 3.0);
+        assert_eq!(rpy.roll_angle(), 1.0);
+        assert_eq!(rpy.pitch_angle(), 2.0);
+        assert_eq!(rpy.yaw_angle(), 3.0);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_vector() {
+        let rpy = RollPitchYaw_new(1.0, 2.0, 3.0);
+        let v = rpy.vector();
+        assert_eq!(v.x(), 1.0);
+        assert_eq!(v.y(), 2.0);
+        assert_eq!(v.z(), 3.0);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_set() {
+        let mut rpy = RollPitchYaw_new(1.0, 2.0, 3.0);
+        RollPitchYaw_set(rpy.as_mut().expect(""), 4.0, 5.0, 6.0);
+        assert_eq!(rpy.roll_angle(), 4.0);
+        assert_eq!(rpy.pitch_angle(), 5.0);
+        assert_eq!(rpy.yaw_angle(), 6.0);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_set_from_quaternion() {
+        let q = Quaternion_new(1.0, 0.0, 0.0, 0.0);
+        let mut rpy = RollPitchYaw_new(1.0, 2.0, 3.0);
+        RollPitchYaw_SetFromQuaternion(rpy.as_mut().expect(""), &q);
+        assert_eq!(rpy.roll_angle(), 0.0);
+        assert_eq!(rpy.pitch_angle(), 0.0);
+        assert_eq!(rpy.yaw_angle(), 0.0);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_to_quaternion() {
+        let rpy = RollPitchYaw_new(0.0, 0.0, 0.0);
+        let q = RollPitchYaw_ToQuaternion(&rpy);
+        assert_eq!(q.w(), 1.);
+        assert_eq!(q.x(), 0.);
+        assert_eq!(q.y(), 0.);
+        assert_eq!(q.z(), 0.);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_to_matrix() {
+        let rpy = RollPitchYaw_new(0.0, 0.0, 0.0);
+        let m = RollPitchYaw_ToMatrix(&rpy);
+        assert_eq!(Matrix3_row(&m, 0).x(), 1.0);
+        assert_eq!(Matrix3_row(&m, 1).y(), 1.0);
+        assert_eq!(Matrix3_row(&m, 2).z(), 1.0);
+    }
+
+    #[test]
+    fn roll_pitch_yaw_calc_rotation_matrix_dt() {
+        let rpy = RollPitchYaw_new(0.0, 0.0, 0.0);
+        let v = Vector3_new(1.0, 1.0, 1.0);
+        let m = RollPitchYaw_CalcRotationMatrixDt(&rpy, &v);
+        assert_eq!(Matrix3_row(&m, 0).x(), 0.0);
+        assert_eq!(Matrix3_row(&m, 1).y(), 0.0);
+        assert_eq!(Matrix3_row(&m, 2).z(), 0.0);
     }
 }

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -30,12 +30,14 @@
 
 #[cfg(test)]
 mod math_test {
-    use maliput_sys::math::ffi::Vector3_new;
-
     use maliput_sys::math::ffi::Vector3_cross;
     use maliput_sys::math::ffi::Vector3_dot;
     use maliput_sys::math::ffi::Vector3_equals;
-    use maliput_sys::math::ffi::Vector3_norm;
+    use maliput_sys::math::ffi::Vector3_new;
+
+    use maliput_sys::math::ffi::Vector4_dot;
+    use maliput_sys::math::ffi::Vector4_equals;
+    use maliput_sys::math::ffi::Vector4_new;
 
     #[test]
     fn vector3_new() {
@@ -48,7 +50,17 @@ mod math_test {
     #[test]
     fn vector3_norm() {
         let v = Vector3_new(1.0, 2.0, 3.0);
-        assert_eq!(Vector3_norm(&v), (v.x() * v.x() + v.y() * v.y() + v.z() * v.z()).sqrt());
+        assert_eq!(v.norm(), (v.x() * v.x() + v.y() * v.y() + v.z() * v.z()).sqrt());
+    }
+
+    #[test]
+    fn vector3_normalize() {
+        let mut v = Vector3_new(1.0, 2.0, 3.0);
+        let norm = v.norm();
+        v.as_mut().expect("").normalize();
+        assert_eq!(v.x(), 1.0 / norm);
+        assert_eq!(v.y(), 2.0 / norm);
+        assert_eq!(v.z(), 3.0 / norm);
     }
 
     #[test]
@@ -73,5 +85,51 @@ mod math_test {
         let v = Vector3_new(1.0, 2.0, 3.0);
         let w = Vector3_new(1.0, 2.0, 3.0);
         assert!(Vector3_equals(&v, &w));
+    }
+
+    #[test]
+    fn vector4_new() {
+        let v = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(v.x(), 1.0);
+        assert_eq!(v.y(), 2.0);
+        assert_eq!(v.z(), 3.0);
+        assert_eq!(v.w(), 4.0);
+    }
+
+    #[test]
+    fn vector4_norm() {
+        let v = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(
+            v.norm(),
+            (v.x() * v.x() + v.y() * v.y() + v.z() * v.z() + v.w() * v.w()).sqrt()
+        );
+    }
+
+    #[test]
+    fn vector4_normalize() {
+        let mut v = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        let norm = v.norm();
+        v.as_mut().expect("").normalize();
+        assert_eq!(v.x(), 1.0 / norm);
+        assert_eq!(v.y(), 2.0 / norm);
+        assert_eq!(v.z(), 3.0 / norm);
+        assert_eq!(v.w(), 4.0 / norm);
+    }
+
+    #[test]
+    fn vector4_dot() {
+        let v = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        let w = Vector4_new(5.0, 6.0, 7.0, 8.0);
+        assert_eq!(
+            Vector4_dot(&v, &w),
+            v.x() * w.x() + v.y() * w.y() + v.z() * w.z() + v.w() * w.w()
+        );
+    }
+
+    #[test]
+    fn vector4_equals() {
+        let v = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        let w = Vector4_new(1.0, 2.0, 3.0, 4.0);
+        assert!(Vector4_equals(&v, &w));
     }
 }

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -236,7 +236,8 @@ mod math_test {
     fn matrix3_transpose() {
         let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
         let t = Matrix3_transpose(&m);
-        assert_eq!(Matrix3_row(&m, 1).z(), Matrix3_row(&t, 2).y());
+        let n = Matrix3_new(1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0);
+        assert!(Matrix3_equals(&t, &n));
     }
 
     #[test]

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -39,6 +39,20 @@ mod math_test {
     use maliput_sys::math::ffi::Vector4_equals;
     use maliput_sys::math::ffi::Vector4_new;
 
+    use maliput_sys::math::ffi::Matrix3_adjoint;
+    use maliput_sys::math::ffi::Matrix3_cofactor_matrix;
+    use maliput_sys::math::ffi::Matrix3_col;
+    use maliput_sys::math::ffi::Matrix3_equals;
+    use maliput_sys::math::ffi::Matrix3_inverse;
+    use maliput_sys::math::ffi::Matrix3_new;
+    use maliput_sys::math::ffi::Matrix3_operator_divide_by_scalar;
+    use maliput_sys::math::ffi::Matrix3_operator_mul;
+    use maliput_sys::math::ffi::Matrix3_operator_sub;
+    use maliput_sys::math::ffi::Matrix3_operator_sum;
+    use maliput_sys::math::ffi::Matrix3_row;
+    use maliput_sys::math::ffi::Matrix3_to_str;
+    use maliput_sys::math::ffi::Matrix3_transpose;
+
     #[test]
     fn vector3_new() {
         let v = Vector3_new(1.0, 2.0, 3.0);
@@ -131,5 +145,149 @@ mod math_test {
         let v = Vector4_new(1.0, 2.0, 3.0, 4.0);
         let w = Vector4_new(1.0, 2.0, 3.0, 4.0);
         assert!(Vector4_equals(&v, &w));
+    }
+
+    #[test]
+    fn matrix3_new() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let row1 = Matrix3_row(&m, 0);
+        let row2 = Matrix3_row(&m, 1);
+        let row3 = Matrix3_row(&m, 2);
+        assert_eq!(row1.x(), 1.0);
+        assert_eq!(row1.y(), 2.0);
+        assert_eq!(row1.z(), 3.0);
+        assert_eq!(row2.x(), 4.0);
+        assert_eq!(row2.y(), 5.0);
+        assert_eq!(row2.z(), 6.0);
+        assert_eq!(row3.x(), 7.0);
+        assert_eq!(row3.y(), 8.0);
+        assert_eq!(row3.z(), 9.0);
+    }
+
+    #[test]
+    fn matrix3_col() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let col1 = Matrix3_col(&m, 0);
+        let col2 = Matrix3_col(&m, 1);
+        let col3 = Matrix3_col(&m, 2);
+        assert_eq!(col1.x(), 1.0);
+        assert_eq!(col1.y(), 4.0);
+        assert_eq!(col1.z(), 7.0);
+        assert_eq!(col2.x(), 2.0);
+        assert_eq!(col2.y(), 5.0);
+        assert_eq!(col2.z(), 8.0);
+        assert_eq!(col3.x(), 3.0);
+        assert_eq!(col3.y(), 6.0);
+        assert_eq!(col3.z(), 9.0);
+    }
+
+    #[test]
+    fn matrix3_cofactor() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        assert_eq!(m.cofactor(0, 0), -3.0);
+        assert_eq!(m.cofactor(0, 1), 6.0);
+        assert_eq!(m.cofactor(0, 2), -3.0);
+        assert_eq!(m.cofactor(1, 0), 6.0);
+        assert_eq!(m.cofactor(1, 1), -12.0);
+        assert_eq!(m.cofactor(1, 2), 6.0);
+        assert_eq!(m.cofactor(2, 0), -3.0);
+        assert_eq!(m.cofactor(2, 1), 6.0);
+        assert_eq!(m.cofactor(2, 2), -3.0);
+    }
+
+    #[test]
+    fn matrix3_cofactor_matrix() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let cofactor_matrix = Matrix3_cofactor_matrix(&m);
+        assert_eq!(Matrix3_row(&cofactor_matrix, 0).x(), m.cofactor(0, 0));
+    }
+
+    #[test]
+    fn matrix3_determinant() {
+        let m = Matrix3_new(6.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        assert_eq!(m.determinant(), -15.);
+    }
+
+    #[test]
+    fn matrix3_is_singular() {
+        let m = Matrix3_new(6.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        assert_eq!(m.is_singular(), m.determinant() == 0.0);
+    }
+
+    #[test]
+    fn matrix3_transpose() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let t = Matrix3_transpose(&m);
+        assert_eq!(Matrix3_row(&m, 1).z(), Matrix3_row(&t, 2).y());
+    }
+
+    #[test]
+    fn matrix3_equals() {
+        let m = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let n = Matrix3_new(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        assert!(Matrix3_equals(&m, &n));
+    }
+
+    #[test]
+    fn matrix3_adjoint() {
+        let m = Matrix3_new(6.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        let adj = Matrix3_adjoint(&m);
+        assert!(Matrix3_equals(&Matrix3_transpose(&Matrix3_cofactor_matrix(&m)), &adj));
+    }
+
+    #[test]
+    fn matrix3_operator_mul() {
+        let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+        let n = Matrix3_new(9., 8., 7., 6., 5., 4., 3., 2., 1.);
+        let p = Matrix3_new(30., 24., 18., 84., 69., 54., 138., 114., 90.);
+        assert!(Matrix3_equals(&p, &Matrix3_operator_mul(&m, &n)));
+    }
+
+    #[test]
+    fn matrix3_inverse() {
+        let k_tolerance = 1e-10;
+        let m = Matrix3_new(1., 12., 3., 8., 5., 3., 6., 14., 9.);
+        let inv = Matrix3_inverse(&m);
+        let identity = Matrix3_new(1., 0., 0., 0., 1., 0., 0., 0., 1.);
+        let product = Matrix3_operator_mul(&m, &inv);
+        assert!((Matrix3_row(&product, 0).x() - Matrix3_row(&identity, 0).x()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 0).y() - Matrix3_row(&identity, 0).y()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 0).z() - Matrix3_row(&identity, 0).z()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 1).x() - Matrix3_row(&identity, 1).x()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 1).y() - Matrix3_row(&identity, 1).y()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 1).z() - Matrix3_row(&identity, 1).z()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 2).x() - Matrix3_row(&identity, 2).x()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 2).y() - Matrix3_row(&identity, 2).y()).abs() < k_tolerance);
+        assert!((Matrix3_row(&product, 2).z() - Matrix3_row(&identity, 2).z()).abs() < k_tolerance);
+    }
+
+    #[test]
+    fn matrix3_operator_sum() {
+        let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+        let n = Matrix3_new(9., 8., 7., 6., 5., 4., 3., 2., 1.);
+        let p = Matrix3_new(10., 10., 10., 10., 10., 10., 10., 10., 10.);
+        assert!(Matrix3_equals(&p, &Matrix3_operator_sum(&m, &n)));
+    }
+
+    #[test]
+    fn matrix3_operator_sub() {
+        let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+        let n = Matrix3_new(9., 8., 7., 6., 5., 4., 3., 2., 1.);
+        let p = Matrix3_new(-8., -6., -4., -2., 0., 2., 4., 6., 8.);
+        assert!(Matrix3_equals(&p, &Matrix3_operator_sub(&m, &n)));
+    }
+
+    #[test]
+    fn matrix3_operator_divide_by_scalar() {
+        let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+        let n = 2.0;
+        let p = Matrix3_new(0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5);
+        assert!(Matrix3_equals(&p, &Matrix3_operator_divide_by_scalar(&m, n)));
+    }
+
+    #[test]
+    fn matrix3_to_str() {
+        let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+        assert_eq!(Matrix3_to_str(&m), "{{1, 2, 3},\n{4, 5, 6},\n{7, 8, 9}}");
     }
 }

--- a/maliput-sys/tests/math_test.rs
+++ b/maliput-sys/tests/math_test.rs
@@ -53,6 +53,17 @@ mod math_test {
     use maliput_sys::math::ffi::Matrix3_to_str;
     use maliput_sys::math::ffi::Matrix3_transpose;
 
+    use maliput_sys::math::ffi::Quaternion_Inverse;
+    use maliput_sys::math::ffi::Quaternion_IsApprox;
+    use maliput_sys::math::ffi::Quaternion_ToRotationMatrix;
+    use maliput_sys::math::ffi::Quaternion_TransformVector;
+    use maliput_sys::math::ffi::Quaternion_coeffs;
+    use maliput_sys::math::ffi::Quaternion_conjugate;
+    use maliput_sys::math::ffi::Quaternion_equals;
+    use maliput_sys::math::ffi::Quaternion_new;
+    use maliput_sys::math::ffi::Quaternion_to_str;
+    use maliput_sys::math::ffi::Quaternion_vec;
+
     #[test]
     fn vector3_new() {
         let v = Vector3_new(1.0, 2.0, 3.0);
@@ -289,5 +300,130 @@ mod math_test {
     fn matrix3_to_str() {
         let m = Matrix3_new(1., 2., 3., 4., 5., 6., 7., 8., 9.);
         assert_eq!(Matrix3_to_str(&m), "{{1, 2, 3},\n{4, 5, 6},\n{7, 8, 9}}");
+    }
+
+    #[test]
+    fn quaternion_new() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(q.w(), 1.0);
+        assert_eq!(q.x(), 2.0);
+        assert_eq!(q.y(), 3.0);
+        assert_eq!(q.z(), 4.0);
+    }
+
+    #[test]
+    fn quaternion_dot() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let r = Quaternion_new(5.0, 6.0, 7.0, 8.0);
+        assert_eq!(q.dot(&r), q.w() * r.w() + q.x() * r.x() + q.y() * r.y() + q.z() * r.z());
+    }
+
+    #[test]
+    fn quaternion_angular_distance() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let r = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(q.AngularDistance(&r), 0.);
+    }
+
+    #[test]
+    fn quaternion_norm() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(
+            q.norm(),
+            (q.w() * q.w() + q.x() * q.x() + q.y() * q.y() + q.z() * q.z()).sqrt()
+        );
+    }
+
+    #[test]
+    fn quaternion_normalize() {
+        let mut q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let norm = q.norm();
+        q.as_mut().expect("").normalize();
+        assert_eq!(q.w(), 1.0 / norm);
+        assert_eq!(q.x(), 2.0 / norm);
+        assert_eq!(q.y(), 3.0 / norm);
+        assert_eq!(q.z(), 4.0 / norm);
+    }
+
+    #[test]
+    fn quaternion_squared_norm() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(
+            q.squared_norm(),
+            q.w() * q.w() + q.x() * q.x() + q.y() * q.y() + q.z() * q.z()
+        );
+    }
+
+    #[test]
+    fn quaternion_vec() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let v = Quaternion_vec(&q);
+        assert_eq!(v.x(), q.x());
+        assert_eq!(v.y(), q.y());
+        assert_eq!(v.z(), q.z());
+    }
+
+    #[test]
+    fn quaternion_coeffs() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let v = Quaternion_coeffs(&q);
+        assert_eq!(v.x(), q.w());
+        assert_eq!(v.y(), q.x());
+        assert_eq!(v.z(), q.y());
+        assert_eq!(v.w(), q.z());
+    }
+
+    #[test]
+    fn quaternion_inverse() {
+        let q = Quaternion_new(1.0, 0.0, 0.0, 0.0);
+        let inv = Quaternion_Inverse(&q);
+        assert!(Quaternion_equals(&inv, &Quaternion_Inverse(&q)));
+    }
+
+    #[test]
+    fn quaternion_equals() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let r = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert!(Quaternion_equals(&q, &r));
+    }
+
+    #[test]
+    fn quaternion_conjugate() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let conj = Quaternion_conjugate(&q);
+        assert_eq!(conj.w(), q.w());
+        assert_eq!(conj.x(), -q.x());
+        assert_eq!(conj.y(), -q.y());
+        assert_eq!(conj.z(), -q.z());
+    }
+
+    #[test]
+    fn quaternion_to_rotation_matrix() {
+        let q = Quaternion_new(1.0, 0.0, 0.0, 0.0);
+        let r = Quaternion_ToRotationMatrix(&q);
+        assert_eq!(Matrix3_row(&r, 0).x(), 1.0);
+        assert_eq!(Matrix3_row(&r, 1).y(), 1.0);
+        assert_eq!(Matrix3_row(&r, 2).z(), 1.0);
+    }
+
+    #[test]
+    fn quaternion_transform_vector() {
+        let q = Quaternion_new(1.0, 0.0, 0.0, 0.0);
+        let v = Vector3_new(1.0, 2.0, 3.0);
+        let w = Quaternion_TransformVector(&q, &v);
+        assert!(Vector3_equals(&w, &v));
+    }
+
+    #[test]
+    fn quaternion_is_approx() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        let r = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert!(Quaternion_IsApprox(&q, &r, 1e-10));
+    }
+
+    #[test]
+    fn quaternion_to_str() {
+        let q = Quaternion_new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(Quaternion_to_str(&q), "(w: 1, x: 2, y: 3, z: 4)");
     }
 }

--- a/maliput/src/math/mod.rs
+++ b/maliput/src/math/mod.rs
@@ -194,6 +194,115 @@ impl std::fmt::Debug for Vector4 {
     }
 }
 
+/// A 3x3 matrix.
+/// Wrapper around C++ implementation `maliput::math::Matrix3`.
+///
+/// ## Example
+///
+/// ```rust, no_run
+/// use maliput::math::Matrix3;
+/// use maliput::math::Vector3;
+///
+/// let row_1 = Vector3::new(1.0, 2.0, 3.0);
+/// let row_2 = Vector3::new(4.0, 5.0, 6.0);
+/// let row_3 = Vector3::new(7.0, 8.0, 9.0);
+/// let m = Matrix3::new(row_1, row_2, row_3);
+/// ```
+pub struct Matrix3 {
+    m: cxx::UniquePtr<maliput_sys::math::ffi::Matrix3>,
+}
+
+impl Matrix3 {
+    /// Create a new `Matrix3` with the given `row1`, `row2`, and `row3`.
+    pub fn new(row1: Vector3, row2: Vector3, row3: Vector3) -> Matrix3 {
+        Matrix3 {
+            m: maliput_sys::math::ffi::Matrix3_new(
+                row1.x(),
+                row1.y(),
+                row1.z(),
+                row2.x(),
+                row2.y(),
+                row2.z(),
+                row3.x(),
+                row3.y(),
+                row3.z(),
+            ),
+        }
+    }
+    /// Get the cofactor of the `Matrix3` at the given `row` and `col`.
+    pub fn cofactor(&self, row: u64, col: u64) -> f64 {
+        self.m.cofactor(row, col)
+    }
+    /// Get the cofactor matrix of the `Matrix3`.
+    pub fn cofactor_matrix(&self) -> Matrix3 {
+        Matrix3 {
+            m: maliput_sys::math::ffi::Matrix3_cofactor_matrix(&self.m),
+        }
+    }
+    /// Get the determinant of the `Matrix3`.
+    pub fn determinant(&self) -> f64 {
+        self.m.determinant()
+    }
+    /// Check if the `Matrix3` is singular.
+    pub fn is_singular(&self) -> bool {
+        self.m.is_singular()
+    }
+    /// Get the row at the given `index`.
+    pub fn row(&self, index: u64) -> Vector3 {
+        Vector3 {
+            v: maliput_sys::math::ffi::Matrix3_row(&self.m, index),
+        }
+    }
+    /// Get the column at the given `index`.
+    pub fn col(&self, index: u64) -> Vector3 {
+        Vector3 {
+            v: maliput_sys::math::ffi::Matrix3_col(&self.m, index),
+        }
+    }
+    /// Get the transpose of the `Matrix3`.
+    pub fn transpose(&self) -> Matrix3 {
+        Matrix3 {
+            m: maliput_sys::math::ffi::Matrix3_transpose(&self.m),
+        }
+    }
+    /// Get the adjoint of the `Matrix3`.
+    pub fn adjoint(&self) -> Matrix3 {
+        Matrix3 {
+            m: maliput_sys::math::ffi::Matrix3_adjoint(&self.m),
+        }
+    }
+    /// Get the inverse of the `Matrix3`.
+    pub fn inverse(&self) -> Matrix3 {
+        Matrix3 {
+            m: maliput_sys::math::ffi::Matrix3_inverse(&self.m),
+        }
+    }
+}
+
+impl PartialEq for Matrix3 {
+    fn eq(&self, other: &Self) -> bool {
+        maliput_sys::math::ffi::Matrix3_equals(&self.m, &other.m)
+    }
+}
+
+impl Eq for Matrix3 {}
+
+impl std::fmt::Display for Matrix3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", maliput_sys::math::ffi::Matrix3_to_str(&self.m))
+    }
+}
+
+impl std::fmt::Debug for Matrix3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Matrix3")
+            .field("row1", &self.row(0))
+            .field("row2", &self.row(1))
+            .field("row3", &self.row(2))
+            .finish()
+    }
+}
+
 mod tests {
     #[test]
     fn vector3_new() {
@@ -288,5 +397,16 @@ mod tests {
         assert_eq!(v.y(), 2.0 / norm);
         assert_eq!(v.z(), 3.0 / norm);
         assert_eq!(v.w(), 4.0 / norm);
+    }
+
+    #[test]
+    fn matrix4_tests() {
+        let row_1 = super::Vector3::new(1.0, 2.0, 3.0);
+        let row_2 = super::Vector3::new(4.0, 5.0, 6.0);
+        let row_3 = super::Vector3::new(7.0, 8.0, 9.0);
+        let _m = super::Matrix3::new(row_1, row_2, row_3);
+        assert_eq!(_m.row(0).x(), 1.0);
+        assert_eq!(_m.col(2).z(), 9.0);
+        // TODO(francocipollone): Add tests for the rest of the API.
     }
 }

--- a/maliput/src/math/mod.rs
+++ b/maliput/src/math/mod.rs
@@ -303,6 +303,119 @@ impl std::fmt::Debug for Matrix3 {
     }
 }
 
+/// A quaternion.
+/// Wrapper around C++ implementation `maliput::math::Quaternion`.
+pub struct Quaternion {
+    q: cxx::UniquePtr<maliput_sys::math::ffi::Quaternion>,
+}
+
+impl Quaternion {
+    /// Create a new `Quaternion` with the given `w`, `x`, `y`, and `z` components.
+    /// The `w` component is the real part of the quaternion.
+    /// The `x`, `y`, and `z` components are the imaginary parts of the quaternion.
+    pub fn new(w: f64, x: f64, y: f64, z: f64) -> Quaternion {
+        Quaternion {
+            q: maliput_sys::math::ffi::Quaternion_new(w, x, y, z),
+        }
+    }
+
+    /// Get the `w` component of the `Quaternion`.
+    pub fn w(&self) -> f64 {
+        self.q.w()
+    }
+
+    /// Get the `x` component of the `Quaternion`.
+    pub fn x(&self) -> f64 {
+        self.q.x()
+    }
+    /// Get the `y` component of the `Quaternion`.
+    pub fn y(&self) -> f64 {
+        self.q.y()
+    }
+    /// Get the `z` component of the `Quaternion`.
+    pub fn z(&self) -> f64 {
+        self.q.z()
+    }
+    /// Returns this quaternion Vector.
+    pub fn vec(&self) -> Vector3 {
+        Vector3 {
+            v: maliput_sys::math::ffi::Quaternion_vec(&self.q),
+        }
+    }
+    /// Returns this quaternion coefficients.
+    pub fn coeffs(&self) -> Vector4 {
+        Vector4 {
+            v: maliput_sys::math::ffi::Quaternion_coeffs(&self.q),
+        }
+    }
+    /// Get the dot product of the `Quaternion` with another `Quaternion`.
+    pub fn dot(&self, other: &Quaternion) -> f64 {
+        self.q.dot(&other.q)
+    }
+    /// Get the angular distance between the `Quaternion` and another `Quaternion`.
+    pub fn angular_distance(&self, other: &Quaternion) -> f64 {
+        self.q.AngularDistance(&other.q)
+    }
+    /// Get the norm of the `Quaternion`.
+    pub fn norm(&self) -> f64 {
+        self.q.norm()
+    }
+    /// Normalize the `Quaternion`.
+    pub fn normalize(&mut self) {
+        self.q.as_mut().expect("Unexpected error").normalize();
+    }
+    /// Get the squared norm of the `Quaternion`.
+    pub fn squared_norm(&self) -> f64 {
+        self.q.squared_norm()
+    }
+    /// Get the inverse of the `Quaternion`.
+    pub fn inverse(&self) -> Quaternion {
+        Quaternion {
+            q: maliput_sys::math::ffi::Quaternion_Inverse(&self.q),
+        }
+    }
+    /// Get the conjugate of the `Quaternion`.
+    pub fn conjugate(&self) -> Quaternion {
+        Quaternion {
+            q: maliput_sys::math::ffi::Quaternion_conjugate(&self.q),
+        }
+    }
+    /// Get the rotation matrix representation of the `Quaternion`.
+    pub fn to_rotation_matrix(&self) -> Matrix3 {
+        let q = maliput_sys::math::ffi::Quaternion_ToRotationMatrix(&self.q);
+        Matrix3 { m: q }
+    }
+    /// Apply the `Quaternion` to a `Vector3`.
+    pub fn transform_vector(&self, v: &Vector3) -> Vector3 {
+        let q = maliput_sys::math::ffi::Quaternion_TransformVector(&self.q, &v.v);
+        Vector3 { v: q }
+    }
+}
+
+impl PartialEq for Quaternion {
+    fn eq(&self, other: &Self) -> bool {
+        maliput_sys::math::ffi::Quaternion_equals(&self.q, &other.q)
+    }
+}
+
+impl Eq for Quaternion {}
+
+impl std::fmt::Display for Quaternion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", maliput_sys::math::ffi::Quaternion_to_str(&self.q))
+    }
+}
+impl std::fmt::Debug for Quaternion {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Quaternion")
+            .field("w", &self.w())
+            .field("x", &self.x())
+            .field("y", &self.y())
+            .field("z", &self.z())
+            .finish()
+    }
+}
+
 mod tests {
     #[test]
     fn vector3_new() {
@@ -407,6 +520,16 @@ mod tests {
         let _m = super::Matrix3::new(row_1, row_2, row_3);
         assert_eq!(_m.row(0).x(), 1.0);
         assert_eq!(_m.col(2).z(), 9.0);
+        // TODO(francocipollone): Add tests for the rest of the API.
+    }
+
+    #[test]
+    fn quaternion_tests() {
+        let q = super::Quaternion::new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(q.w(), 1.0);
+        assert_eq!(q.x(), 2.0);
+        assert_eq!(q.y(), 3.0);
+        assert_eq!(q.z(), 4.0);
         // TODO(francocipollone): Add tests for the rest of the API.
     }
 }

--- a/maliput/src/math/mod.rs
+++ b/maliput/src/math/mod.rs
@@ -70,7 +70,11 @@ impl Vector3 {
     }
     /// Get the norm of the `Vector3`.
     pub fn norm(&self) -> f64 {
-        maliput_sys::math::ffi::Vector3_norm(&self.v)
+        self.v.norm()
+    }
+    /// Normalize the `Vector3`.
+    pub fn normalize(&mut self) {
+        self.v.as_mut().expect("Unexpected error").normalize();
     }
     /// Get the dot product of the `Vector3` with another `Vector3`.
     pub fn dot(&self, w: &Vector3) -> f64 {
@@ -108,6 +112,88 @@ impl std::fmt::Debug for Vector3 {
     }
 }
 
+/// A 4D vector.
+/// Wrapper around C++ implementation `maliput::math::Vector4`.
+///
+/// ## Example
+///
+/// ```rust, no_run
+/// use maliput::math::Vector4;
+///
+/// let v = Vector4::new(1.0, 2.0, 3.0, 4.0);
+/// println!("v = {}", v);
+/// assert_eq!(v.x(), 1.0);
+/// assert_eq!(v.y(), 2.0);
+/// assert_eq!(v.z(), 3.0);
+/// assert_eq!(v.w(), 4.0);
+/// assert_eq!(v.norm(), (1.0_f64.powi(2) + 2.0_f64.powi(2) + 3.0_f64.powi(2) + 4.0_f64.powi(2)).sqrt());
+/// ```
+pub struct Vector4 {
+    v: cxx::UniquePtr<maliput_sys::math::ffi::Vector4>,
+}
+
+impl Vector4 {
+    /// Create a new `Vector4` with the given `x`, `y`, `z` and `w` components.
+    pub fn new(x: f64, y: f64, z: f64, w: f64) -> Vector4 {
+        Vector4 {
+            v: maliput_sys::math::ffi::Vector4_new(x, y, z, w),
+        }
+    }
+    /// Get the `x` component of the `Vector4`.
+    pub fn x(&self) -> f64 {
+        self.v.x()
+    }
+    /// Get the `y` component of the `Vector4`.
+    pub fn y(&self) -> f64 {
+        self.v.y()
+    }
+    /// Get the `z` component of the `Vector4`.
+    pub fn z(&self) -> f64 {
+        self.v.z()
+    }
+    /// Get the `w` component of the `Vector4`.
+    pub fn w(&self) -> f64 {
+        self.v.w()
+    }
+    /// Get the norm of the `Vector4`.
+    pub fn norm(&self) -> f64 {
+        self.v.norm()
+    }
+    /// Get the dot product of the `Vector4` with another `Vector4`.
+    pub fn dot(&self, w: &Vector4) -> f64 {
+        maliput_sys::math::ffi::Vector4_dot(&self.v, &w.v)
+    }
+    /// Normalize the `Vector4`.
+    pub fn normalize(&mut self) {
+        self.v.as_mut().expect("Unexpected error").normalize();
+    }
+}
+
+impl PartialEq for Vector4 {
+    fn eq(&self, other: &Self) -> bool {
+        maliput_sys::math::ffi::Vector4_equals(&self.v, &other.v)
+    }
+}
+
+impl Eq for Vector4 {}
+
+impl std::fmt::Display for Vector4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", maliput_sys::math::ffi::Vector4_to_str(&self.v))
+    }
+}
+
+impl std::fmt::Debug for Vector4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Vector4")
+            .field("x", &self.x())
+            .field("y", &self.y())
+            .field("z", &self.z())
+            .field("w", &self.z())
+            .finish()
+    }
+}
+
 mod tests {
     #[test]
     fn vector3_new() {
@@ -118,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn equality() {
+    fn vector3_equality() {
         let v = super::Vector3::new(1.0, 2.0, 3.0);
         let w = super::Vector3::new(1.0, 2.0, 3.0);
         assert_eq!(v, w);
@@ -130,6 +216,16 @@ mod tests {
     fn vector3_norm() {
         let v = super::Vector3::new(1.0, 2.0, 3.0);
         assert_eq!(v.norm(), (v.x() * v.x() + v.y() * v.y() + v.z() * v.z()).sqrt());
+    }
+
+    #[test]
+    fn vector3_normalize() {
+        let mut v = super::Vector3::new(1.0, 2.0, 3.0);
+        let norm = v.norm();
+        v.normalize();
+        assert_eq!(v.x(), 1.0 / norm);
+        assert_eq!(v.y(), 2.0 / norm);
+        assert_eq!(v.z(), 3.0 / norm);
     }
 
     #[test]
@@ -147,5 +243,50 @@ mod tests {
         assert_eq!(cross.x(), v.y() * w.z() - v.z() * w.y());
         assert_eq!(cross.y(), v.z() * w.x() - v.x() * w.z());
         assert_eq!(cross.z(), v.x() * w.y() - v.y() * w.x());
+    }
+
+    #[test]
+    fn vector4_new() {
+        let v = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(v.x(), 1.0);
+        assert_eq!(v.y(), 2.0);
+        assert_eq!(v.z(), 3.0);
+        assert_eq!(v.w(), 4.0);
+    }
+
+    #[test]
+    fn vector4_equality() {
+        let v = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        let w = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(v, w);
+        let z = super::Vector4::new(4.0, 5.0, 6.0, 7.0);
+        assert_ne!(v, z);
+    }
+
+    #[test]
+    fn vector4_norm() {
+        let v = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(
+            v.norm(),
+            (v.x() * v.x() + v.y() * v.y() + v.z() * v.z() + v.w() * v.w()).sqrt()
+        );
+    }
+
+    #[test]
+    fn vector4_dot() {
+        let v = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        let w = super::Vector4::new(4.0, 5.0, 6.0, 7.0);
+        assert_eq!(v.dot(&w), v.x() * w.x() + v.y() * w.y() + v.z() * w.z() + v.w() * w.w());
+    }
+
+    #[test]
+    fn vector4_normalize() {
+        let mut v = super::Vector4::new(1.0, 2.0, 3.0, 4.0);
+        let norm = v.norm();
+        v.normalize();
+        assert_eq!(v.x(), 1.0 / norm);
+        assert_eq!(v.y(), 2.0 / norm);
+        assert_eq!(v.z(), 3.0 / norm);
+        assert_eq!(v.w(), 4.0 / norm);
     }
 }


### PR DESCRIPTION
# 🎉 New feature

Related to #11  #14 

## Summary
- FFI Bindings for:
  -  Vector4, Matrix3, Quaternion
- Rust API for:
  -  Vector4, Matrix3, Quaternion

- https://github.com/maliput/maliput-rs/pull/44 was merged into this branch/PR


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

