### PR TITLE
Bindings for Segment class and RoadGeometry::get_segment.

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -90,6 +90,10 @@ bool InertialPosition_operator_eq(const InertialPosition& lhs, const InertialPos
   return lhs == rhs;
 }
 
+rust::String Segment_id(const Segment& segment) {
+  return segment.id().string();
+}
+
 rust::String Lane_id(const Lane& lane) {
   return lane.id().string();
 }
@@ -149,6 +153,10 @@ const std::vector<ConstLanePtr>& RoadGeometry_GetLanes(const RoadGeometry& road_
     lanes.push_back(ConstLanePtr{lane.second});
   }
   return lanes;
+}
+
+const Segment* RoadGeometry_GetSegment(const RoadGeometry& road_geometry, const rust::String& segment_id) {
+  return road_geometry.ById().GetSegment(SegmentId{std::string(segment_id)});
 }
 
 std::unique_ptr<Rotation> Rotation_new() {

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -64,6 +64,7 @@ pub mod ffi {
         ) -> UniquePtr<RoadPositionResult>;
         fn RoadGeometry_GetLane(rg: &RoadGeometry, lane_id: &String) -> ConstLanePtr;
         fn RoadGeometry_GetLanes(rg: &RoadGeometry) -> &CxxVector<ConstLanePtr>;
+        fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;
@@ -106,6 +107,12 @@ pub mod ffi {
         fn Lane_id(lane: &Lane) -> String;
         fn Lane_GetOrientation(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<Rotation>;
         fn Lane_ToInertialPosition(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<InertialPosition>;
+
+        // Segment bindings definitions
+        type Segment;
+        fn num_lanes(self: &Segment) -> i32;
+        fn lane(self: &Segment, index: i32) -> *const Lane;
+        fn Segment_id(segment: &Segment) -> String;
 
         // RoadPosition bindings definitions
         type RoadPosition;

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -143,6 +143,16 @@ impl<'a> RoadGeometry<'a> {
             })
             .collect::<Vec<Lane>>()
     }
+    /// Get the segment matching given `segment_id`.
+    pub fn get_segment(&self, segment_id: &String) -> Segment {
+        unsafe {
+            Segment {
+                segment: maliput_sys::api::ffi::RoadGeometry_GetSegment(self.rg, segment_id)
+                    .as_ref()
+                    .expect(""),
+            }
+        }
+    }
 }
 
 /// A RoadNetwork.
@@ -479,6 +489,38 @@ impl<'a> Lane<'a> {
     pub fn to_inertial_position(&self, lane_position: &LanePosition) -> InertialPosition {
         InertialPosition {
             ip: maliput_sys::api::ffi::Lane_ToInertialPosition(self.lane, lane_position.lp.as_ref().expect("")),
+        }
+    }
+}
+
+/// A Segment represents a bundle of adjacent Lanes which share a
+/// continuously traversable road surface. Every [LanePosition] on a
+/// given [Lane] of a Segment has a corresponding [LanePosition] on each
+/// other [Lane], all with the same height-above-surface h, that all
+/// map to the same GeoPoint in 3-space.
+///
+/// Segments are grouped by [Junction].
+///
+/// Wrapper around C++ implementation `maliput::api::Segment`.
+pub struct Segment<'a> {
+    segment: &'a maliput_sys::api::ffi::Segment,
+}
+
+impl<'a> Segment<'a> {
+    /// Get the id of the `Segment` as a string.
+    pub fn id(&self) -> String {
+        maliput_sys::api::ffi::Segment_id(self.segment)
+    }
+    /// Get the number of lanes in the `Segment`.
+    pub fn num_lanes(&self) -> i32 {
+        self.segment.num_lanes()
+    }
+    /// Get the lane at the given `index`.
+    pub fn lane(&self, index: i32) -> Lane {
+        unsafe {
+            Lane {
+                lane: self.segment.lane(index).as_ref().expect(""),
+            }
         }
     }
 }

--- a/maliput/tests/segment_test.rs
+++ b/maliput/tests/segment_test.rs
@@ -30,50 +30,16 @@
 mod common;
 
 #[test]
-fn linear_tolerance() {
+fn lane_api() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
-    assert_eq!(road_geometry.linear_tolerance(), 0.01);
-}
-
-#[test]
-fn to_road_position() {
-    let expected_nearest_position = maliput::api::InertialPosition::new(5.0, 1.75, 0.0);
-    let expected_lane_position = maliput::api::LanePosition::new(5.0, 0.0, 0.0);
-    let expected_lane_id = String::from("0_0_1");
-    let road_network = common::create_t_shape_road_network();
-    let road_geometry = road_network.road_geometry();
-
-    let road_position_result = road_geometry.to_road_position(&expected_nearest_position);
-    assert_eq!(road_position_result.road_position.lane().id(), expected_lane_id);
-    common::assert_lane_position_equality(
-        &road_position_result.road_position.pos(),
-        &expected_lane_position,
-        road_geometry.linear_tolerance(),
-    );
-    common::assert_inertial_position_equality(
-        &road_position_result.nearest_position,
-        &expected_nearest_position,
-        road_geometry.linear_tolerance(),
-    );
-}
-
-#[test]
-fn by_index() {
-    let road_network = common::create_t_shape_road_network();
-    let road_geometry = road_network.road_geometry();
-    let lane_id = String::from("0_0_1");
-    let lane = road_geometry.get_lane(&lane_id);
-    assert_eq!(lane.id(), "0_0_1");
-
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
 
     let segment_id = String::from("0_0");
     let segment = road_geometry.get_segment(&segment_id);
-    assert_eq!(segment.id(), "0_0");
+    assert_eq!(segment.id(), segment_id);
+
+    let num_lanes = segment.num_lanes();
+    assert_eq!(num_lanes, 2);
+    let lane = segment.lane(0);
+    assert_eq!(lane.id(), String::from("0_0_-1"));
 }


### PR DESCRIPTION
# 🎉 New feature

Related to #49 #48 #36 #31 

## Summary
- FFI bindings for Segment
- Rust API for Segment
- RoadGeometry::get_segment method.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)


