### PR TITLE
Adds all Junction, RoadGeometry::get_junction, Segment::junction bindings

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -34,10 +34,12 @@
 #include <sstream>
 #include <vector>
 
+#include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_network.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/api/segment.h>
 
 #include <rust/cxx.h>
 
@@ -94,6 +96,10 @@ rust::String Segment_id(const Segment& segment) {
   return segment.id().string();
 }
 
+rust::String Junction_id(const Junction& junction) {
+  return junction.id().string();
+}
+
 rust::String Lane_id(const Lane& lane) {
   return lane.id().string();
 }
@@ -134,6 +140,10 @@ double RoadPositionResult_distance(const RoadPositionResult& road_pos_res) {
   return road_pos_res.distance;
 }
 
+rust::String RoadGeometry_id(const RoadGeometry& road_geometry) {
+  return road_geometry.id().string();
+}
+
 std::unique_ptr<RoadPositionResult> RoadGeometry_ToRoadPosition(const RoadGeometry& road_geometry, const InertialPosition& inertial_pos) {
   return std::make_unique<RoadPositionResult>(road_geometry.ToRoadPosition(inertial_pos));
 }
@@ -157,6 +167,10 @@ const std::vector<ConstLanePtr>& RoadGeometry_GetLanes(const RoadGeometry& road_
 
 const Segment* RoadGeometry_GetSegment(const RoadGeometry& road_geometry, const rust::String& segment_id) {
   return road_geometry.ById().GetSegment(SegmentId{std::string(segment_id)});
+}
+
+const Junction* RoadGeometry_GetJunction(const RoadGeometry& road_geometry, const rust::String& junction_id) {
+  return road_geometry.ById().GetJunction(JunctionId{std::string(junction_id)});
 }
 
 std::unique_ptr<Rotation> Rotation_new() {

--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -90,6 +90,10 @@ bool InertialPosition_operator_eq(const InertialPosition& lhs, const InertialPos
   return lhs == rhs;
 }
 
+rust::String Segment_id(const Segment& segment) {
+  return segment.id().string();
+}
+
 rust::String Lane_id(const Lane& lane) {
   return lane.id().string();
 }
@@ -149,6 +153,10 @@ const std::vector<ConstLanePtr>& RoadGeometry_GetLanes(const RoadGeometry& road_
     lanes.push_back(ConstLanePtr{lane.second});
   }
   return lanes;
+}
+
+const Segment* RoadGeometry_GetSegment(const RoadGeometry& road_geometry, const rust::String& segment_id) {
+  return road_geometry.ById().GetSegment(SegmentId{std::string(segment_id)});
 }
 
 std::unique_ptr<Rotation> Rotation_new() {

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -53,6 +53,7 @@ pub mod ffi {
         type RoadGeometry;
         // RoadNetwork bindings definitions.
         fn road_geometry(self: &RoadNetwork) -> *const RoadGeometry;
+        fn RoadGeometry_id(road_geometry: &RoadGeometry) -> String;
         // RoadGeometry bindings definitions.
         fn num_junctions(self: &RoadGeometry) -> i32;
         fn linear_tolerance(self: &RoadGeometry) -> f64;
@@ -65,6 +66,7 @@ pub mod ffi {
         fn RoadGeometry_GetLane(rg: &RoadGeometry, lane_id: &String) -> ConstLanePtr;
         fn RoadGeometry_GetLanes(rg: &RoadGeometry) -> &CxxVector<ConstLanePtr>;
         fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
+        fn RoadGeometry_GetJunction(rg: &RoadGeometry, junction_id: &String) -> *const Junction;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;
@@ -111,8 +113,16 @@ pub mod ffi {
         // Segment bindings definitions
         type Segment;
         fn num_lanes(self: &Segment) -> i32;
+        fn junction(self: &Segment) -> *const Junction;
         fn lane(self: &Segment, index: i32) -> *const Lane;
         fn Segment_id(segment: &Segment) -> String;
+
+        // Junction bindings definitions
+        type Junction;
+        fn road_geometry(self: &Junction) -> *const RoadGeometry;
+        fn num_segments(self: &Junction) -> i32;
+        fn segment(self: &Junction, index: i32) -> *const Segment;
+        fn Junction_id(junction: &Junction) -> String;
 
         // RoadPosition bindings definitions
         type RoadPosition;

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -64,6 +64,7 @@ pub mod ffi {
         ) -> UniquePtr<RoadPositionResult>;
         fn RoadGeometry_GetLane(rg: &RoadGeometry, lane_id: &String) -> ConstLanePtr;
         fn RoadGeometry_GetLanes(rg: &RoadGeometry) -> &CxxVector<ConstLanePtr>;
+        fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;
@@ -106,6 +107,12 @@ pub mod ffi {
         fn Lane_id(lane: &Lane) -> String;
         fn Lane_GetOrientation(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<Rotation>;
         fn Lane_ToInertialPosition(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<InertialPosition>;
+
+        // Segment bindings definitions
+        type Segment;
+        fn num_lanes(self: &Segment) -> i32;
+        fn lane(self: &Segment, index: i32) -> *const Lane;
+        fn Segment_id(segment: &Segment) -> String;
 
         // RoadPosition bindings definitions
         type RoadPosition;

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -143,6 +143,16 @@ impl<'a> RoadGeometry<'a> {
             })
             .collect::<Vec<Lane>>()
     }
+    /// Get the segment matching given `segment_id`.
+    pub fn get_segment(&self, segment_id: &String) -> Segment {
+        unsafe {
+            Segment {
+                segment: maliput_sys::api::ffi::RoadGeometry_GetSegment(self.rg, segment_id)
+                    .as_ref()
+                    .expect(""),
+            }
+        }
+    }
 }
 
 /// A RoadNetwork.
@@ -479,6 +489,38 @@ impl<'a> Lane<'a> {
     pub fn to_inertial_position(&self, lane_position: &LanePosition) -> InertialPosition {
         InertialPosition {
             ip: maliput_sys::api::ffi::Lane_ToInertialPosition(self.lane, lane_position.lp.as_ref().expect("")),
+        }
+    }
+}
+
+/// A Segment represents a bundle of adjacent Lanes which share a
+/// continuously traversable road surface. Every [LanePosition] on a
+/// given [Lane] of a Segment has a corresponding [LanePosition] on each
+/// other [Lane], all with the same height-above-surface h, that all
+/// map to the same GeoPoint in 3-space.
+///
+/// Segments are grouped by [Junction].
+///
+/// Wrapper around C++ implementation `maliput::api::Segment`.
+pub struct Segment<'a> {
+    segment: &'a maliput_sys::api::ffi::Segment,
+}
+
+impl<'a> Segment<'a> {
+    /// Get the id of the `Segment` as a string.
+    pub fn id(&self) -> String {
+        maliput_sys::api::ffi::Segment_id(self.segment)
+    }
+    /// Get the number of lanes in the `Segment`.
+    pub fn num_lanes(&self) -> i32 {
+        self.segment.num_lanes()
+    }
+    /// Get the lane at the given `index`.
+    pub fn lane(&self, index: i32) -> Lane {
+        unsafe {
+            Lane {
+                lane: self.segment.lane(index).as_ref().expect(""),
+            }
         }
     }
 }

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -41,6 +41,10 @@ pub struct RoadGeometry<'a> {
 }
 
 impl<'a> RoadGeometry<'a> {
+    /// Returns the id of the RoadGeometry.
+    pub fn id(&self) -> String {
+        maliput_sys::api::ffi::RoadGeometry_id(self.rg)
+    }
     /// Returns the number of Junctions in the RoadGeometry.
     ///
     /// Return value is non-negative.
@@ -148,6 +152,16 @@ impl<'a> RoadGeometry<'a> {
         unsafe {
             Segment {
                 segment: maliput_sys::api::ffi::RoadGeometry_GetSegment(self.rg, segment_id)
+                    .as_ref()
+                    .expect(""),
+            }
+        }
+    }
+    /// Get the junction matching given `junction_id`.
+    pub fn get_junction(&self, junction_id: &String) -> Junction {
+        unsafe {
+            Junction {
+                junction: maliput_sys::api::ffi::RoadGeometry_GetJunction(self.rg, junction_id)
                     .as_ref()
                     .expect(""),
             }
@@ -511,6 +525,14 @@ impl<'a> Segment<'a> {
     pub fn id(&self) -> String {
         maliput_sys::api::ffi::Segment_id(self.segment)
     }
+    /// Returns the [Junction] to which this Segment belongs.
+    pub fn junction(&self) -> Junction {
+        unsafe {
+            Junction {
+                junction: self.segment.junction().as_ref().expect(""),
+            }
+        }
+    }
     /// Get the number of lanes in the `Segment`.
     pub fn num_lanes(&self) -> i32 {
         self.segment.num_lanes()
@@ -520,6 +542,46 @@ impl<'a> Segment<'a> {
         unsafe {
             Lane {
                 lane: self.segment.lane(index).as_ref().expect(""),
+            }
+        }
+    }
+}
+
+/// A Junction is a closed set of [Segment]s which have physically
+/// coplanar road surfaces, in the sense that [RoadPosition]s with the
+/// same h value (height above surface) in the domains of two [Segment]s
+/// map to the same [InertialPosition].  The [Segment]s need not be directly
+/// connected to one another in the network topology.
+///
+/// Junctions are grouped by [RoadGeometry].
+///
+/// Wrapper around C++ implementation `maliput::api::Segment`.
+pub struct Junction<'a> {
+    junction: &'a maliput_sys::api::ffi::Junction,
+}
+
+impl<'a> Junction<'a> {
+    /// Get the id of the `Junction` as a string.
+    pub fn id(&self) -> String {
+        maliput_sys::api::ffi::Junction_id(self.junction)
+    }
+    /// Get the road geometry of the `Junction`.
+    pub fn road_geometry(&self) -> RoadGeometry {
+        unsafe {
+            RoadGeometry {
+                rg: self.junction.road_geometry().as_ref().expect(""),
+            }
+        }
+    }
+    /// Get the number of segments in the `Junction`.
+    pub fn num_segments(&self) -> i32 {
+        self.junction.num_segments()
+    }
+    /// Get the segment at the given `index`.
+    pub fn segment(&self, index: i32) -> Segment {
+        unsafe {
+            Segment {
+                segment: self.junction.segment(index).as_ref().expect(""),
             }
         }
     }

--- a/maliput/tests/junction_tests.rs
+++ b/maliput/tests/junction_tests.rs
@@ -30,17 +30,15 @@
 mod common;
 
 #[test]
-fn segment_api() {
+fn junction_api() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
-
-    let segment_id = String::from("0_0");
-    let segment = road_geometry.get_segment(&segment_id);
-    assert_eq!(segment.id(), segment_id);
-    let junction = segment.junction();
-    assert_eq!(junction.id(), String::from("0_0"));
-    let num_lanes = segment.num_lanes();
-    assert_eq!(num_lanes, 2);
-    let lane = segment.lane(0);
-    assert_eq!(lane.id(), String::from("0_0_-1"));
+    let junction_id = String::from("0_0");
+    let junction = road_geometry.get_junction(&junction_id);
+    assert_eq!(junction.road_geometry().id(), road_geometry.id());
+    assert_eq!(junction.id(), junction_id);
+    let num_segments = junction.num_segments();
+    assert_eq!(num_segments, 1);
+    let segment = junction.segment(0);
+    assert_eq!(segment.id(), String::from("0_0"));
 }

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -30,10 +30,18 @@
 mod common;
 
 #[test]
-fn linear_tolerance() {
+fn id() {
+    let road_network = common::create_t_shape_road_network();
+    let road_geometry = road_network.road_geometry();
+    assert_eq!(road_geometry.id(), "my_rg_from_rust");
+}
+
+#[test]
+fn tolerances() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
     assert_eq!(road_geometry.linear_tolerance(), 0.01);
+    assert_eq!(road_geometry.angular_tolerance(), 0.01);
 }
 
 #[test]
@@ -76,4 +84,8 @@ fn by_index() {
     let segment_id = String::from("0_0");
     let segment = road_geometry.get_segment(&segment_id);
     assert_eq!(segment.id(), "0_0");
+
+    let junction_id = String::from("0_0");
+    let junction = road_geometry.get_junction(&junction_id);
+    assert_eq!(junction.id(), "0_0");
 }

--- a/maliput/tests/segment_test.rs
+++ b/maliput/tests/segment_test.rs
@@ -30,50 +30,16 @@
 mod common;
 
 #[test]
-fn linear_tolerance() {
+fn lane_api() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
-    assert_eq!(road_geometry.linear_tolerance(), 0.01);
-}
-
-#[test]
-fn to_road_position() {
-    let expected_nearest_position = maliput::api::InertialPosition::new(5.0, 1.75, 0.0);
-    let expected_lane_position = maliput::api::LanePosition::new(5.0, 0.0, 0.0);
-    let expected_lane_id = String::from("0_0_1");
-    let road_network = common::create_t_shape_road_network();
-    let road_geometry = road_network.road_geometry();
-
-    let road_position_result = road_geometry.to_road_position(&expected_nearest_position);
-    assert_eq!(road_position_result.road_position.lane().id(), expected_lane_id);
-    common::assert_lane_position_equality(
-        &road_position_result.road_position.pos(),
-        &expected_lane_position,
-        road_geometry.linear_tolerance(),
-    );
-    common::assert_inertial_position_equality(
-        &road_position_result.nearest_position,
-        &expected_nearest_position,
-        road_geometry.linear_tolerance(),
-    );
-}
-
-#[test]
-fn by_index() {
-    let road_network = common::create_t_shape_road_network();
-    let road_geometry = road_network.road_geometry();
-    let lane_id = String::from("0_0_1");
-    let lane = road_geometry.get_lane(&lane_id);
-    assert_eq!(lane.id(), "0_0_1");
-
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
-    let lanes = road_geometry.get_lanes();
-    assert_eq!(lanes.len(), 12);
 
     let segment_id = String::from("0_0");
     let segment = road_geometry.get_segment(&segment_id);
-    assert_eq!(segment.id(), "0_0");
+    assert_eq!(segment.id(), segment_id);
+
+    let num_lanes = segment.num_lanes();
+    assert_eq!(num_lanes, 2);
+    let lane = segment.lane(0);
+    assert_eq!(lane.id(), String::from("0_0_-1"));
 }


### PR DESCRIPTION
# 🎉 New feature
:exclamation:  Goes on top of #50 

Related to #31 #36 #48 #49 #17 #28

## Summary
 - maliput::api::Junction FFI bindings and Rust API
 - maliput::api::Segment::junction method
 - maliput::api::RoadGeometry::id method
 - maliput::api::RoadGeometry::get_junction method

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

