### PR TITLE
Bazel ignore target folder when package is being created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides a Rust API for maliput.
 
 * [`maliput-sdk`](./maliput-sdk/): Brings binaries of maliput ecosystem to cargo workspace.
 * [`maliput-sys`](./maliput-sys/): Provides ffi Rust bindings for the [`maliput`](https://github.com/maliput/maliput) API.
-* [`maliput`]: Provides a Rustacean API for maliput on top of `maliput-sys`.
+* [`maliput`](./maliput/): Provides a Rustacean API for maliput on top of `maliput-sys`.
 
 ## Prerequisites
 

--- a/maliput-sdk/.bazelignore
+++ b/maliput-sdk/.bazelignore
@@ -1,1 +1,1 @@
-maliput_malidrive
+target


### PR DESCRIPTION
# 🦟 Bug fix

Related to #52 

### Summary

When cargo package is executed the target folder temporary created was causing the bazel build execution to fail.  
