### PR TITLE
Adds Lane::segment method coverage.

### DIFF
--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -108,6 +108,7 @@ pub mod ffi {
         fn index(self: &Lane) -> i32;
         fn length(self: &Lane) -> f64;
         fn Contains(self: &Lane, lane_position: &LanePosition) -> bool;
+        fn segment(self: &Lane) -> *const Segment;
         fn Lane_id(lane: &Lane) -> String;
         fn Lane_lane_bounds(lane: &Lane, s: f64) -> UniquePtr<RBounds>;
         fn Lane_segment_bounds(lane: &Lane, s: f64) -> UniquePtr<RBounds>;

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -543,6 +543,14 @@ impl<'a> Lane<'a> {
     pub fn id(&self) -> String {
         maliput_sys::api::ffi::Lane_id(self.lane)
     }
+    /// Returns the Segment to which this Lane belongs.
+    pub fn segment(&self) -> Segment<'a> {
+        unsafe {
+            Segment {
+                segment: self.lane.segment().as_ref().expect(""),
+            }
+        }
+    }
     /// Get the orientation of the `Lane` at the given `LanePosition`.
     pub fn get_orientation(&self, lane_position: &LanePosition) -> Rotation {
         Rotation {

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -72,4 +72,7 @@ fn lane_api() {
     // In TShapeRoad map there is a right lane from current lane.
     assert!(right_lane.is_some());
     assert_eq!(right_lane.unwrap().id(), "0_0_-1");
+    let segment = lane.segment();
+    let expected_segment_id = String::from("0_0");
+    assert_eq!(segment.id(), expected_segment_id);
 }


### PR DESCRIPTION
# 🎉 New feature

Related to #38 #37 

## Summary
 - Adds bindings for Lane::Segment method.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
