### PR TITLE
Adds LaneEnd.

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -270,5 +270,9 @@ std::unique_ptr<LaneSRange> LaneSRange_GetIntersection(const LaneSRange& lane_s_
   return nullptr;
 }
 
+std::unique_ptr<LaneEnd> LaneEnd_new(const Lane* lane, bool start) {
+  return std::make_unique<LaneEnd>(lane, start ? LaneEnd::kStart : LaneEnd::kFinish);
+}
+
 } // namespace api
 } // namespace maliput

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -205,6 +205,16 @@ pub mod ffi {
             other: &LaneSRange,
             tolerance: f64,
         ) -> UniquePtr<LaneSRange>;
+
+        // LaneEnd bindings definitions
+        type LaneEnd;
+        // maliput::api Rust will have its own LaneEnd enum.
+        // However, this LaneEnd_new is expected to be used on methods that return a Cpp LaneEnd
+        // and a conversion to Rust LaneEnd is needed.
+        /// # Safety
+        /// This function is unsafe because it dereferences `lane` pointer.
+        unsafe fn LaneEnd_new(lane: *const Lane, start: bool) -> UniquePtr<LaneEnd>;
+
     }
     impl UniquePtr<RoadNetwork> {}
     impl UniquePtr<LanePosition> {}

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -973,6 +973,15 @@ impl LaneSRange {
     }
 }
 
+/// A specific endpoint of a specific Lane.
+/// This is analogous to the C++ maliput::api::LaneEnd implementation.
+pub enum LaneEnd<'a> {
+    /// The start of the Lane. ("s == 0")
+    Start(&'a Lane<'a>),
+    /// The end of the Lane. ("s == length")
+    Finish(&'a Lane<'a>),
+}
+
 mod tests {
     mod lane_position {
         #[test]

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -76,3 +76,22 @@ fn lane_api() {
     let expected_segment_id = String::from("0_0");
     assert_eq!(segment.id(), expected_segment_id);
 }
+
+#[test]
+fn lane_end_test() {
+    let road_network = common::create_t_shape_road_network();
+    let road_geometry = road_network.road_geometry();
+
+    let lane_id = String::from("0_0_1");
+    let lane = road_geometry.get_lane(&lane_id);
+    let lane_end_start = maliput::api::LaneEnd::Start(&lane);
+    match lane_end_start {
+        maliput::api::LaneEnd::Start(lane) => assert_eq!(lane.id(), lane_id),
+        maliput::api::LaneEnd::Finish(_) => panic!("Expected Start, got Finish"),
+    }
+    let lane_end_end = maliput::api::LaneEnd::Finish(&lane);
+    match lane_end_end {
+        maliput::api::LaneEnd::Start(_) => panic!("Expected Finish, got Start"),
+        maliput::api::LaneEnd::Finish(lane) => assert_eq!(lane.id(), lane_id),
+    }
+}


### PR DESCRIPTION
# 🎉 New feature

#28 #17 

## Summary
 - maliput: Adds LaneEnd implementation in Rust.
 - maliput_sys: LaneEnd type and LaneEnd_new method is added to be used later on in methods that return LaneEnds. 


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
