### PR TITLE
Bindings for LaneEndSet and BranchPoint abstraction.

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <vector>
 
+#include <maliput/api/branch_point.h>
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
@@ -272,6 +273,14 @@ std::unique_ptr<LaneSRange> LaneSRange_GetIntersection(const LaneSRange& lane_s_
 
 std::unique_ptr<LaneEnd> LaneEnd_new(const Lane* lane, bool start) {
   return std::make_unique<LaneEnd>(lane, start ? LaneEnd::kStart : LaneEnd::kFinish);
+}
+
+const Lane* LaneEnd_lane(const LaneEnd& lane_end) {
+  return lane_end.lane;
+}
+
+bool LaneEnd_is_start(const LaneEnd& lane_end) {
+  return lane_end.end == LaneEnd::kStart;
 }
 
 } // namespace api

--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -199,6 +199,10 @@ const std::vector<ConstLanePtr>& RoadGeometry_GetLanes(const RoadGeometry& road_
   return lanes;
 }
 
+const BranchPoint* RoadGeometry_GetBranchPoint(const RoadGeometry& road_geometry, const rust::String& branch_point_id) {
+  return road_geometry.ById().GetBranchPoint(BranchPointId{std::string(branch_point_id)});
+}
+
 const Segment* RoadGeometry_GetSegment(const RoadGeometry& road_geometry, const rust::String& segment_id) {
   return road_geometry.ById().GetSegment(SegmentId{std::string(segment_id)});
 }
@@ -281,6 +285,15 @@ const Lane* LaneEnd_lane(const LaneEnd& lane_end) {
 
 bool LaneEnd_is_start(const LaneEnd& lane_end) {
   return lane_end.end == LaneEnd::kStart;
+}
+
+rust::String BranchPoint_id(const BranchPoint& branch_point) {
+  return branch_point.id().string();
+}
+
+std::unique_ptr<LaneEnd> BranchPoint_GetDefaultBranch(const BranchPoint& branch_point, const LaneEnd& end) {
+  const auto default_branch = branch_point.GetDefaultBranch(end);
+  return default_branch ? std::make_unique<LaneEnd>(*default_branch) : nullptr;
 }
 
 } // namespace api

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -67,6 +67,7 @@ pub mod ffi {
         fn RoadGeometry_GetLanes(rg: &RoadGeometry) -> &CxxVector<ConstLanePtr>;
         fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
         fn RoadGeometry_GetJunction(rg: &RoadGeometry, junction_id: &String) -> *const Junction;
+        fn RoadGeometry_GetBranchPoint(rg: &RoadGeometry, branch_point_id: &String) -> *const BranchPoint;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;
@@ -221,6 +222,16 @@ pub mod ffi {
         type LaneEndSet;
         fn size(self: &LaneEndSet) -> i32;
         fn get(self: &LaneEndSet, index: i32) -> &LaneEnd;
+
+        // BranchPoint bindings definitions
+        type BranchPoint;
+        fn BranchPoint_id(branch_point: &BranchPoint) -> String;
+        fn road_geometry(self: &BranchPoint) -> *const RoadGeometry;
+        fn GetConfluentBranches(self: &BranchPoint, end: &LaneEnd) -> *const LaneEndSet;
+        fn GetOngoingBranches(self: &BranchPoint, end: &LaneEnd) -> *const LaneEndSet;
+        fn GetASide(self: &BranchPoint) -> *const LaneEndSet;
+        fn GetBSide(self: &BranchPoint) -> *const LaneEndSet;
+        fn BranchPoint_GetDefaultBranch(branch_point: &BranchPoint, end: &LaneEnd) -> UniquePtr<LaneEnd>;
     }
     impl UniquePtr<RoadNetwork> {}
     impl UniquePtr<LanePosition> {}

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -214,7 +214,13 @@ pub mod ffi {
         /// # Safety
         /// This function is unsafe because it dereferences `lane` pointer.
         unsafe fn LaneEnd_new(lane: *const Lane, start: bool) -> UniquePtr<LaneEnd>;
+        fn LaneEnd_lane(lane_end: &LaneEnd) -> *const Lane;
+        fn LaneEnd_is_start(lane_end: &LaneEnd) -> bool;
 
+        // LaneEndSet bindings definitions
+        type LaneEndSet;
+        fn size(self: &LaneEndSet) -> i32;
+        fn get(self: &LaneEndSet, index: i32) -> &LaneEnd;
     }
     impl UniquePtr<RoadNetwork> {}
     impl UniquePtr<LanePosition> {}

--- a/maliput/tests/branch_point_tests.rs
+++ b/maliput/tests/branch_point_tests.rs
@@ -1,0 +1,66 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+mod common;
+
+#[test]
+fn branch_point_api() {
+    let road_network = common::create_t_shape_road_network();
+    let road_geometry = road_network.road_geometry();
+    let branch_point_id = String::from("2");
+    let branch_point = road_geometry.get_branch_point(&branch_point_id);
+    assert_eq!(branch_point.id(), branch_point_id);
+    assert_eq!(branch_point.road_geometry().id(), road_geometry.id());
+    // Testing that the api works. The actual values are not important, they are tested in the
+    // cpp tests.
+    let lane_end_set = branch_point.get_a_side();
+    assert_eq!(lane_end_set.size(), 1);
+    let lane_end = lane_end_set.get(0);
+    let confluent_branches = branch_point.get_confluent_branches(&lane_end);
+    assert_eq!(confluent_branches.size(), 1);
+    let ongoing_branches = branch_point.get_ongoing_branches(&lane_end);
+    assert_eq!(ongoing_branches.size(), 2);
+    let lane_end_set = branch_point.get_b_side();
+    assert_eq!(lane_end_set.size(), 2);
+
+    // Test default branch.
+    let default_lane_end = branch_point.get_default_branch(&lane_end);
+    assert!(default_lane_end.is_some());
+    match default_lane_end.unwrap() {
+        maliput::api::LaneEnd::Start(l) | maliput::api::LaneEnd::Finish(l) => assert_eq!(l.id(), "9_0_-1"),
+    }
+
+    // Test that the default branch is None when the lane_end point to the other side.
+    let the_other_lane_end = match lane_end {
+        maliput::api::LaneEnd::Start(l) => maliput::api::LaneEnd::Finish(l),
+        maliput::api::LaneEnd::Finish(l) => maliput::api::LaneEnd::Start(l),
+    };
+    let default_branch = branch_point.get_default_branch(&the_other_lane_end);
+    assert!(default_branch.is_none());
+}

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -94,9 +94,3 @@ fn lane_end_test() {
         maliput::api::LaneEnd::Finish(lane) => assert_eq!(lane.id(), lane_id),
     }
 }
-
-#[test]
-fn lane_end_set_test() {
-    // TODO: Implement this test once BranchPoint is implemented as
-    //       the latter provides methods to get LaneEndSet.
-}

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -83,15 +83,20 @@ fn lane_end_test() {
     let road_geometry = road_network.road_geometry();
 
     let lane_id = String::from("0_0_1");
-    let lane = road_geometry.get_lane(&lane_id);
-    let lane_end_start = maliput::api::LaneEnd::Start(&lane);
+    let lane_end_start = maliput::api::LaneEnd::Start(road_geometry.get_lane(&lane_id));
     match lane_end_start {
         maliput::api::LaneEnd::Start(lane) => assert_eq!(lane.id(), lane_id),
         maliput::api::LaneEnd::Finish(_) => panic!("Expected Start, got Finish"),
     }
-    let lane_end_end = maliput::api::LaneEnd::Finish(&lane);
+    let lane_end_end = maliput::api::LaneEnd::Finish(road_geometry.get_lane(&lane_id));
     match lane_end_end {
         maliput::api::LaneEnd::Start(_) => panic!("Expected Finish, got Start"),
         maliput::api::LaneEnd::Finish(lane) => assert_eq!(lane.id(), lane_id),
     }
+}
+
+#[test]
+fn lane_end_set_test() {
+    // TODO: Implement this test once BranchPoint is implemented as
+    //       the latter provides methods to get LaneEndSet.
 }


### PR DESCRIPTION
# 🎉 New feature

On top of #61 

Related to 
#28 #17 

## Summary
Add LaneEndSet

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
