### PR TITLE
Adds ResourceManager and offer malidrive resources.

### DIFF
--- a/maliput-sdk/BUILD.bazel
+++ b/maliput-sdk/BUILD.bazel
@@ -22,6 +22,9 @@ cc_binary(
         "@maliput//:utility",
         "@maliput_malidrive//:maliput_plugins/libmaliput_malidrive_road_network.so",
     ],
+    data = [
+        "@maliput_malidrive//resources:all"
+    ],
     linkshared = True,
     linkstatic = False
 )

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -88,6 +88,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // ************* maliput_malidrive header files ************* //
     // TODO(francocipollone): For consistency we should also add include paths for maliput_malidrive.
 
+    // ************* maliput_malidrive resource files ************* //
+    let maliput_malidrive_resource_path = bazel_bin_dir
+        .join("libmaliput_sdk.so.runfiles")
+        .join(String::from("maliput_malidrive~") + maliput_malidrive_version)
+        .join("resources");
+
     // ************* crate output env vars ************* //
 
     // Environment variable to pass down to this crate:
@@ -99,6 +105,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "cargo:rustc-env=MALIPUT_MALIDRIVE_PLUGIN_PATH={}",
         maliput_malidrive_bin_path.join("maliput_plugins").display()
+    );
+    println!(
+        "cargo:rustc-env=MALIPUT_MALIDRIVE_RESOURCE_PATH={}",
+        maliput_malidrive_resource_path.display()
     );
 
     // Environment variable to pass down to dependent crates:

--- a/maliput/src/lib.rs
+++ b/maliput/src/lib.rs
@@ -29,3 +29,118 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 pub mod api;
 pub mod math;
+
+/// ### ResourceManager
+///
+/// Convenient method for getting the path to the resources of the backends.
+///
+/// ### Backends
+///  - maliput_malidrive: Resources from maliput_malidrive are brought by maliput-sdk package.
+///                       All the maliput_malidrive resources are stored in the same directory:
+///                       (See https://github.com/maliput/maliput_malidrive/tree/main/resources)
+/// ### Example
+///
+/// How to get all the resources from the maliput_malidrive backend:
+///
+/// ```rust, no_run
+/// let resource_manager = maliput::ResourceManager::new();
+/// let all_resources_in_malidrive = resource_manager.get_all_resources_by_backend("maliput_malidrive");
+/// ```
+///
+/// How to get the path to the TShapeRoad.xodr file from the maliput_malidrive backend:
+/// ```rust, no_run
+/// let resource_manager = maliput::ResourceManager::new();
+/// let t_shape_road_xodr_path = resource_manager.get_resource_path_by_name("maliput_malidrive", "TShapeRoad.xodr");
+/// assert!(t_shape_road_xodr_path.is_some());
+/// assert!(t_shape_road_xodr_path.unwrap().exists());
+/// ```
+pub struct ResourceManager {
+    resource_paths: std::collections::HashMap<String, Vec<std::path::PathBuf>>,
+}
+
+impl Default for ResourceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResourceManager {
+    /// Creates a new ResourceManager.
+    pub fn new() -> ResourceManager {
+        let mut resource_paths = std::collections::HashMap::new();
+        maliput_sdk::sdk_resources()
+            .iter()
+            .for_each(|(backend_name, resource_path)| {
+                // All the files in the path are added to the resource manager
+                let files = std::fs::read_dir(resource_path).unwrap();
+                let mut paths = vec![];
+                files.filter(|file| file.is_ok()).for_each(|file| {
+                    paths.push(file.unwrap().path());
+                });
+                resource_paths.insert(backend_name.clone(), paths);
+            });
+        ResourceManager { resource_paths }
+    }
+
+    /// Obtains the path to a resource by its name.
+    /// ### Arguments
+    ///
+    /// * `backend_name` - The name of the backend.
+    /// * `resource_name` - The name of the resource.
+    ///
+    /// ### Returns
+    /// The path to the resource if it exists, otherwise None.
+    pub fn get_resource_path_by_name(&self, backend_name: &str, resource_name: &str) -> Option<std::path::PathBuf> {
+        let paths = self.resource_paths.get(backend_name).unwrap();
+        for path in paths {
+            if path.to_str().unwrap().contains(resource_name) {
+                return Some(path.clone());
+            }
+        }
+        None
+    }
+
+    /// Obtains all the resources from a backend.
+    /// ### Arguments
+    ///
+    /// * `backend_name` - The name of the backend.
+    ///
+    /// ### Returns
+    /// A vector with all the resources from the backend if it exists, otherwise None.
+    pub fn get_all_resources_by_backend(&self, backend_name: &str) -> Option<&Vec<std::path::PathBuf>> {
+        self.resource_paths.get(backend_name)
+    }
+
+    /// Get the underlying collection that stores all the resources for each backend.
+    pub fn get_all_resources(&self) -> &std::collections::HashMap<String, Vec<std::path::PathBuf>> {
+        &self.resource_paths
+    }
+}
+
+// test
+
+mod tests {
+
+    #[test]
+    fn test_maliput_malidrive_resources() {
+        let resource_manager = crate::ResourceManager::new();
+
+        let t_shape_road_xodr_path = resource_manager.get_resource_path_by_name("maliput_malidrive", "TShapeRoad.xodr");
+        assert!(t_shape_road_xodr_path.is_some());
+        assert!(t_shape_road_xodr_path.unwrap().exists());
+
+        let wrong_file_path = resource_manager.get_resource_path_by_name("maliput_malidrive", "wrong_file");
+        assert!(wrong_file_path.is_none());
+
+        let all_resources_in_malidrive = resource_manager.get_all_resources_by_backend("maliput_malidrive");
+        assert!(all_resources_in_malidrive.is_some());
+        assert!(all_resources_in_malidrive.unwrap().len() > 10);
+
+        let all_resources_in_wrong_backend = resource_manager.get_all_resources_by_backend("wrong_backend");
+        assert!(all_resources_in_wrong_backend.is_none());
+
+        let all_resources = resource_manager.get_all_resources();
+        // There is only one backend supported at the moment.
+        assert_eq!(all_resources.len(), 1);
+    }
+}


### PR DESCRIPTION
# 🎉 New feature

Closes #33 

## Summary
 - maliput: Adds maliput::ResourceManager abstraction to offer the backend resources: maliput_malidrive at the moment.
 - maliput-sdk: Offer the resources of the backends.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

