### PR TITLE
Updates documentation link for the cargo packages.

### DIFF
--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.2"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."
-documentation = "https://maliput.readthedocs.io/"
+documentation = "https://maliput.github.io/maliput-rs/maliput_sdk"
 readme = "README.md"
 
 edition.workspace = true

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "FFI Rust bindings for maliput"
-documentation = "https://maliput.readthedocs.io/"
+documentation = "https://maliput.github.io/maliput-rs/maliput_sys"
 readme = "README.md"
 
 edition.workspace = true

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["simulation"]
 description = "Rust API for maliput"
-documentation = "https://docs.rs/crate/maliput"
+documentation = "https://maliput.github.io/maliput-rs/maliput"
 readme = "README.md"
 
 edition.workspace = true


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/maliput/maliput-rs/issues/70

## Summary
We can now rely on online documentation:
 - https://maliput.github.io/maliput-rs/maliput
 - https://maliput.github.io/maliput-rs/maliput_sys
 - https://maliput.github.io/maliput-rs/maliput_sdk

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
