### PR TITLE
RoadGeometryt::get_lane returns an Option.

### DIFF
--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -109,15 +109,19 @@ impl<'a> RoadGeometry<'a> {
         }
     }
     /// Get the lane matching given `lane_id`.
-    pub fn get_lane(&self, lane_id: &String) -> Lane {
-        unsafe {
-            Lane {
-                lane: maliput_sys::api::ffi::RoadGeometry_GetLane(self.rg, lane_id)
-                    .lane
-                    .as_ref()
-                    .expect(""),
-            }
+    /// ### Arguments
+    /// * `lane_id` - The id of the lane.
+    /// ### Return
+    /// The lane with the given id.
+    /// If no lane is found with the given id, return None.
+    pub fn get_lane(&self, lane_id: &String) -> Option<Lane> {
+        let lane = maliput_sys::api::ffi::RoadGeometry_GetLane(self.rg, lane_id);
+        if lane.lane.is_null() {
+            return None;
         }
+        Some(Lane {
+            lane: unsafe { lane.lane.as_ref().expect("") },
+        })
     }
     /// Get all lanes of the `RoadGeometry`.
     /// Returns a vector of `Lane`.

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -103,8 +103,8 @@ fn lane_end_api_test() {
     let road_geometry = road_network.road_geometry();
 
     let lane_id = String::from("0_0_1");
-    let lane_end_start = maliput::api::LaneEnd::Start(road_geometry.get_lane(&lane_id));
-    let lane_end_end = maliput::api::LaneEnd::Finish(road_geometry.get_lane(&lane_id));
+    let lane_end_start = maliput::api::LaneEnd::Start(road_geometry.get_lane(&lane_id).unwrap());
+    let lane_end_end = maliput::api::LaneEnd::Finish(road_geometry.get_lane(&lane_id).unwrap());
     assert_eq!(&lane_end_start, &lane_end_start);
     assert_ne!(&lane_end_start, &lane_end_end);
     match lane_end_start {

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -72,7 +72,8 @@ fn by_index() {
     let road_geometry = road_network.road_geometry();
     let lane_id = String::from("0_0_1");
     let lane = road_geometry.get_lane(&lane_id);
-    assert_eq!(lane.id(), "0_0_1");
+    assert!(lane.is_some());
+    assert_eq!(lane.unwrap().id(), "0_0_1");
 
     let lanes = road_geometry.get_lanes();
     assert_eq!(lanes.len(), 12);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #90 

## Summary
Described in the issue

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
