### PR TITLE
Adds bindings/rust api for Bulb.

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -35,6 +35,37 @@ pub mod ffi {
     struct ConstTrafficLightPtr {
         pub traffic_light: *const TrafficLight,
     }
+    /// Shared struct for `BulbState` references.
+    /// This is needed because `&f` can't be used directly in the CxxVector collection.
+    struct ConstBulbStateRef<'a> {
+        pub bulb_state: &'a BulbState,
+    }
+    /// Shared struct for floats types.
+    /// This is needed because `f64` can't be used directly in the UniquePtr type.
+    struct FloatWrapper {
+        pub value: f64,
+    }
+
+    #[repr(i32)]
+    enum BulbColor {
+        kRed = 0,
+        kYellow,
+        kGreen,
+    }
+
+    #[repr(i32)]
+    enum BulbType {
+        kRound = 0,
+        kArrow,
+    }
+
+    #[repr(i32)]
+    enum BulbState {
+        kOff = 0,
+        kOn,
+        kBlinking,
+    }
+
     unsafe extern "C++" {
         include!("api/rules/rules.h");
 
@@ -43,6 +74,8 @@ pub mod ffi {
         type InertialPosition = crate::api::ffi::InertialPosition;
         #[namespace = "maliput::api"]
         type Rotation = crate::api::ffi::Rotation;
+        #[namespace = "maliput::math"]
+        type Vector3 = crate::math::ffi::Vector3;
 
         // TrafficLightBook bindings definitions.
         type TrafficLightBook;
@@ -54,5 +87,22 @@ pub mod ffi {
         fn TrafficLight_id(traffic_light: &TrafficLight) -> String;
         fn TrafficLight_position_road_network(traffic_light: &TrafficLight) -> UniquePtr<InertialPosition>;
         fn TrafficLight_orientation_road_network(traffic_light: &TrafficLight) -> UniquePtr<Rotation>;
+
+        type BulbColor;
+        type BulbState;
+        type BulbType;
+        type Bulb;
+        fn Bulb_id(bulb: &Bulb) -> String;
+        fn Bulb_position_bulb_group(bulb: &Bulb) -> UniquePtr<InertialPosition>;
+        fn Bulb_orientation_bulb_group(bulb: &Bulb) -> UniquePtr<Rotation>;
+        fn color(self: &Bulb) -> &BulbColor;
+        // We can't automatically use the name `type` as it is a reserved keyword in Rust.
+        fn Bulb_type(bulb: &Bulb) -> &BulbType;
+        fn Bulb_arrow_orientation_rad(bulb: &Bulb) -> UniquePtr<FloatWrapper>;
+        fn Bulb_states(bulb: &Bulb) -> UniquePtr<CxxVector<ConstBulbStateRef>>;
+        fn GetDefaultState(self: &Bulb) -> BulbState;
+        fn IsValidState(self: &Bulb, state: &BulbState) -> bool;
+        fn Bulb_bounding_box_min(bulb: &Bulb) -> UniquePtr<Vector3>;
+        fn Bulb_bounding_box_max(bulb: &Bulb) -> UniquePtr<Vector3>;
     }
 }

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -34,6 +34,7 @@
 
 #include <maliput/api/rules/traffic_lights.h>
 #include <maliput/api/rules/traffic_light_book.h>
+#include <maliput/math/vector.h>
 
 #include <rust/cxx.h>
 
@@ -67,6 +68,45 @@ std::unique_ptr<maliput::api::InertialPosition> TrafficLight_position_road_netwo
 
 std::unique_ptr<maliput::api::Rotation> TrafficLight_orientation_road_network(const TrafficLight& traffic_light) {
   return std::make_unique<maliput::api::Rotation>(traffic_light.orientation_road_network());
+}
+
+rust::String Bulb_id(const Bulb& bulb) {
+  return bulb.id().string();
+}
+
+std::unique_ptr<maliput::api::InertialPosition> Bulb_position_bulb_group(const Bulb& bulb) {
+  return std::make_unique<maliput::api::InertialPosition>(bulb.position_bulb_group());
+}
+
+std::unique_ptr<maliput::api::Rotation> Bulb_orientation_bulb_group(const Bulb& bulb) {
+  return std::make_unique<maliput::api::Rotation>(bulb.orientation_bulb_group());
+}
+
+const BulbType& Bulb_type(const Bulb& bulb) {
+  return bulb.type();
+}
+
+std::unique_ptr<FloatWrapper> Bulb_arrow_orientation_rad(const Bulb& bulb) {
+  const auto orientation = bulb.arrow_orientation_rad();
+  return orientation.has_value() ? std::make_unique<FloatWrapper>(FloatWrapper{orientation.value()}) : nullptr;
+}
+
+std::unique_ptr<std::vector<ConstBulbStateRef>> Bulb_states(const Bulb& bulb) {
+  const auto states_cpp = bulb.states();
+  std::vector<ConstBulbStateRef> states;
+  states.reserve(states_cpp.size());
+  for (const auto state : states_cpp) {
+    states.push_back({state});
+  }
+  return std::make_unique<std::vector<ConstBulbStateRef>>(std::move(states));
+}
+
+std::unique_ptr<maliput::math::Vector3> Bulb_bounding_box_min(const Bulb& bulb) {
+  return std::make_unique<maliput::math::Vector3>(bulb.bounding_box().p_BMin);
+}
+
+std::unique_ptr<maliput::math::Vector3> Bulb_bounding_box_max(const Bulb& bulb) {
+  return std::make_unique<maliput::math::Vector3>(bulb.bounding_box().p_BMax);
 }
 
 }  // namespace rules

--- a/maliput/src/math/mod.rs
+++ b/maliput/src/math/mod.rs
@@ -46,7 +46,7 @@
 /// assert_eq!(v.cross(&v), Vector3::new(0.0, 0.0, 0.0));
 /// ```
 pub struct Vector3 {
-    v: cxx::UniquePtr<maliput_sys::math::ffi::Vector3>,
+    pub(crate) v: cxx::UniquePtr<maliput_sys::math::ffi::Vector3>,
 }
 
 impl Vector3 {


### PR DESCRIPTION
# 🎉 New feature

:exclamation:  Goes on top of #98

Related to #100 #99 

## Summary
 - Complete almost the entire API. Binded methods are updated in the issue.

Tests are referred to when we have BulbGroup class also added.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

