### PR TITLE
Adds bindings/rust API for BulbGroup abstraction.

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -31,9 +31,19 @@
 #[cxx::bridge(namespace = "maliput::api::rules")]
 pub mod ffi {
     /// Shared struct for `TrafficLight` pointers.
-    /// This is needed because `*const f` can't be used directly in the CxxVector collection.
+    /// This is needed because `*const` can't be used directly in the CxxVector collection.
     struct ConstTrafficLightPtr {
         pub traffic_light: *const TrafficLight,
+    }
+    /// Shared struct for `BulbGroup` pointers.
+    /// This is needed because `*const` can't be used directly in the CxxVector collection.
+    struct ConstBulbGroupPtr {
+        pub bulb_group: *const BulbGroup,
+    }
+    /// Shared struct for `Bulb` pointers.
+    /// This is needed because `*const` can't be used directly in the CxxVector collection.
+    struct ConstBulbPtr {
+        pub bulb: *const Bulb,
     }
     /// Shared struct for `BulbState` references.
     /// This is needed because `&f` can't be used directly in the CxxVector collection.
@@ -87,10 +97,13 @@ pub mod ffi {
         fn TrafficLight_id(traffic_light: &TrafficLight) -> String;
         fn TrafficLight_position_road_network(traffic_light: &TrafficLight) -> UniquePtr<InertialPosition>;
         fn TrafficLight_orientation_road_network(traffic_light: &TrafficLight) -> UniquePtr<Rotation>;
+        fn TrafficLight_bulb_groups(traffic_light: &TrafficLight) -> UniquePtr<CxxVector<ConstBulbGroupPtr>>;
+        fn TrafficLight_GetBulbGroup(traffic_light: &TrafficLight, id: &String) -> *const BulbGroup;
 
         type BulbColor;
         type BulbState;
         type BulbType;
+        // Bulb bindings definitions.
         type Bulb;
         fn Bulb_id(bulb: &Bulb) -> String;
         fn Bulb_position_bulb_group(bulb: &Bulb) -> UniquePtr<InertialPosition>;
@@ -99,10 +112,20 @@ pub mod ffi {
         // We can't automatically use the name `type` as it is a reserved keyword in Rust.
         fn Bulb_type(bulb: &Bulb) -> &BulbType;
         fn Bulb_arrow_orientation_rad(bulb: &Bulb) -> UniquePtr<FloatWrapper>;
-        fn Bulb_states(bulb: &Bulb) -> UniquePtr<CxxVector<ConstBulbStateRef>>;
+        fn Bulb_states(bulb: &Bulb) -> UniquePtr<CxxVector<BulbState>>;
         fn GetDefaultState(self: &Bulb) -> BulbState;
         fn IsValidState(self: &Bulb, state: &BulbState) -> bool;
         fn Bulb_bounding_box_min(bulb: &Bulb) -> UniquePtr<Vector3>;
         fn Bulb_bounding_box_max(bulb: &Bulb) -> UniquePtr<Vector3>;
+        fn Bulb_bulb_group(bulb: &Bulb) -> *const BulbGroup;
+
+        // BulbGroup bindings definitions.
+        type BulbGroup;
+        fn BulbGroup_id(bulb_group: &BulbGroup) -> String;
+        fn BulbGroup_position_traffic_light(bulb_group: &BulbGroup) -> UniquePtr<InertialPosition>;
+        fn BulbGroup_orientation_traffic_light(bulb_group: &BulbGroup) -> UniquePtr<Rotation>;
+        fn BulbGroup_bulbs(bulb_group: &BulbGroup) -> UniquePtr<CxxVector<ConstBulbPtr>>;
+        fn BulbGroup_GetBulb(bulb_group: &BulbGroup, id: &String) -> *const Bulb;
+        fn BulbGroup_traffic_light(bulb_group: &BulbGroup) -> *const TrafficLight;
     }
 }

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -70,6 +70,20 @@ std::unique_ptr<maliput::api::Rotation> TrafficLight_orientation_road_network(co
   return std::make_unique<maliput::api::Rotation>(traffic_light.orientation_road_network());
 }
 
+std::unique_ptr<std::vector<ConstBulbGroupPtr>> TrafficLight_bulb_groups(const TrafficLight& traffic_light) {
+  const auto bulb_groups_cpp = traffic_light.bulb_groups();
+  std::vector<ConstBulbGroupPtr> bulb_groups;
+  bulb_groups.reserve(bulb_groups_cpp.size());
+  for (const auto bulb_group : bulb_groups_cpp) {
+    bulb_groups.push_back({bulb_group});
+  }
+  return std::make_unique<std::vector<ConstBulbGroupPtr>>(std::move(bulb_groups));
+}
+
+const BulbGroup* TrafficLight_GetBulbGroup(const TrafficLight& traffic_light, const rust::String& id) {
+  return traffic_light.GetBulbGroup(BulbGroup::Id{std::string(id)});
+}
+
 rust::String Bulb_id(const Bulb& bulb) {
   return bulb.id().string();
 }
@@ -91,14 +105,14 @@ std::unique_ptr<FloatWrapper> Bulb_arrow_orientation_rad(const Bulb& bulb) {
   return orientation.has_value() ? std::make_unique<FloatWrapper>(FloatWrapper{orientation.value()}) : nullptr;
 }
 
-std::unique_ptr<std::vector<ConstBulbStateRef>> Bulb_states(const Bulb& bulb) {
+std::unique_ptr<std::vector<BulbState>> Bulb_states(const Bulb& bulb) {
   const auto states_cpp = bulb.states();
-  std::vector<ConstBulbStateRef> states;
+  std::vector<BulbState> states;
   states.reserve(states_cpp.size());
   for (const auto state : states_cpp) {
-    states.push_back({state});
+    states.push_back(state);
   }
-  return std::make_unique<std::vector<ConstBulbStateRef>>(std::move(states));
+  return std::make_unique<std::vector<BulbState>>(std::move(states));
 }
 
 std::unique_ptr<maliput::math::Vector3> Bulb_bounding_box_min(const Bulb& bulb) {
@@ -107,6 +121,40 @@ std::unique_ptr<maliput::math::Vector3> Bulb_bounding_box_min(const Bulb& bulb) 
 
 std::unique_ptr<maliput::math::Vector3> Bulb_bounding_box_max(const Bulb& bulb) {
   return std::make_unique<maliput::math::Vector3>(bulb.bounding_box().p_BMax);
+}
+
+const BulbGroup* Bulb_bulb_group(const Bulb& bulb) {
+  return bulb.bulb_group();
+}
+
+rust::String BulbGroup_id(const BulbGroup& bulb_group) {
+  return bulb_group.id().string();
+}
+
+std::unique_ptr<InertialPosition> BulbGroup_position_traffic_light(const BulbGroup& bulb_group) {
+  return std::make_unique<InertialPosition>(bulb_group.position_traffic_light());
+}
+
+std::unique_ptr<Rotation> BulbGroup_orientation_traffic_light(const BulbGroup& bulb_group) {
+  return std::make_unique<Rotation>(bulb_group.orientation_traffic_light());
+}
+
+std::unique_ptr<std::vector<ConstBulbPtr>> BulbGroup_bulbs(const BulbGroup& bulb_group) {
+  const auto bulbs_cpp = bulb_group.bulbs();
+  std::vector<ConstBulbPtr> bulbs;
+  bulbs.reserve(bulbs_cpp.size());
+  for (const auto bulb : bulbs_cpp) {
+    bulbs.push_back({bulb});
+  }
+  return std::make_unique<std::vector<ConstBulbPtr>>(std::move(bulbs));
+}
+
+const Bulb* BulbGroup_GetBulb(const BulbGroup& bulb_group, const rust::String& id) {
+  return bulb_group.GetBulb(Bulb::Id{std::string(id)});
+}
+
+const TrafficLight* BulbGroup_traffic_light(const BulbGroup& bulb_group) {
+  return bulb_group.traffic_light();
 }
 
 }  // namespace rules


### PR DESCRIPTION
# 🎉 New feature

Related to :
 - https://github.com/maliput/maliput-rs/issues/95
 - #100 
 - #103
 - https://github.com/maliput/maliput-rs/issues/99
 - https://github.com/maliput/maliput-rs/issues/96
 - https://github.com/maliput/maliput-rs/issues/102
 - 

## Summary
 - Adds bindings for BulbGroup
 - Adds rust API for BulbGroup
 - Adds method for TrafficLights to get BulbGroups
 - Adds method for Bulbs to get BulbGroup

 - Tests are added.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
