### PR TITLE
Release maliput-sys v0.1.1 and maliput v0.1.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maliput"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "cxx",
@@ -344,7 +344,7 @@ version = "0.1.3"
 
 [[package]]
 name = "maliput-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "FFI Rust bindings for maliput"
@@ -16,7 +16,7 @@ build = "build.rs"
 
 [dependencies]
 cxx = "1.0.78"
-maliput-sdk = { version = "0.1.2",  path = "../maliput-sdk" }
+maliput-sdk = { version = "0.1.3",  path = "../maliput-sdk" }
 
 [build-dependencies]
 cxx-build = "1.0.78"

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["simulation"]
 description = "Rust API for maliput"
@@ -14,8 +14,8 @@ repository.workspace = true
 
 [dependencies]
 cxx = "1.0.78"
-maliput-sdk = { version = "0.1.2", path = "../maliput-sdk" }
-maliput-sys = { version = "0.1.0", path = "../maliput-sys" }
+maliput-sdk = { version = "0.1.3", path = "../maliput-sdk" }
+maliput-sys = { version = "0.1.1", path = "../maliput-sys" }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
 - Rely on new release of maliput-sdk #84 (which brings spiral support)
 - Release TrafficLight and Intersection related stuff.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
