### PR TITLE
UniqueBulbId and UniqueBulbGroupId abstractions.

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -106,6 +106,7 @@ pub mod ffi {
         // Bulb bindings definitions.
         type Bulb;
         fn Bulb_id(bulb: &Bulb) -> String;
+        fn Bulb_unique_id(bulb: &Bulb) -> UniquePtr<UniqueBulbId>;
         fn Bulb_position_bulb_group(bulb: &Bulb) -> UniquePtr<InertialPosition>;
         fn Bulb_orientation_bulb_group(bulb: &Bulb) -> UniquePtr<Rotation>;
         fn color(self: &Bulb) -> &BulbColor;
@@ -122,10 +123,24 @@ pub mod ffi {
         // BulbGroup bindings definitions.
         type BulbGroup;
         fn BulbGroup_id(bulb_group: &BulbGroup) -> String;
+        fn BulbGroup_unique_id(bulb: &BulbGroup) -> UniquePtr<UniqueBulbGroupId>;
         fn BulbGroup_position_traffic_light(bulb_group: &BulbGroup) -> UniquePtr<InertialPosition>;
         fn BulbGroup_orientation_traffic_light(bulb_group: &BulbGroup) -> UniquePtr<Rotation>;
         fn BulbGroup_bulbs(bulb_group: &BulbGroup) -> UniquePtr<CxxVector<ConstBulbPtr>>;
         fn BulbGroup_GetBulb(bulb_group: &BulbGroup, id: &String) -> *const Bulb;
         fn BulbGroup_traffic_light(bulb_group: &BulbGroup) -> *const TrafficLight;
+
+        // UniqueBulbId bindings definitions.
+        type UniqueBulbId;
+        fn string(self: &UniqueBulbId) -> &CxxString;
+        fn UniqueBulbId_traffic_light_id(id: &UniqueBulbId) -> String;
+        fn UniqueBulbId_bulb_group_id(id: &UniqueBulbId) -> String;
+        fn UniqueBulbId_bulb_id(id: &UniqueBulbId) -> String;
+
+        // UniqueBulbGroupId bindings definitions.
+        type UniqueBulbGroupId;
+        fn string(self: &UniqueBulbGroupId) -> &CxxString;
+        fn UniqueBulbGroupId_traffic_light_id(id: &UniqueBulbGroupId) -> String;
+        fn UniqueBulbGroupId_bulb_group_id(id: &UniqueBulbGroupId) -> String;
     }
 }

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -84,6 +84,10 @@ const BulbGroup* TrafficLight_GetBulbGroup(const TrafficLight& traffic_light, co
   return traffic_light.GetBulbGroup(BulbGroup::Id{std::string(id)});
 }
 
+std::unique_ptr<UniqueBulbId> Bulb_unique_id(const Bulb& bulb) {
+  return std::make_unique<UniqueBulbId>(bulb.unique_id());
+}
+
 rust::String Bulb_id(const Bulb& bulb) {
   return bulb.id().string();
 }
@@ -131,6 +135,10 @@ rust::String BulbGroup_id(const BulbGroup& bulb_group) {
   return bulb_group.id().string();
 }
 
+std::unique_ptr<UniqueBulbGroupId> BulbGroup_unique_id(const BulbGroup& bulb_group) {
+  return std::make_unique<UniqueBulbGroupId>(bulb_group.unique_id());
+}
+
 std::unique_ptr<InertialPosition> BulbGroup_position_traffic_light(const BulbGroup& bulb_group) {
   return std::make_unique<InertialPosition>(bulb_group.position_traffic_light());
 }
@@ -155,6 +163,26 @@ const Bulb* BulbGroup_GetBulb(const BulbGroup& bulb_group, const rust::String& i
 
 const TrafficLight* BulbGroup_traffic_light(const BulbGroup& bulb_group) {
   return bulb_group.traffic_light();
+}
+
+rust::String UniqueBulbId_traffic_light_id(const UniqueBulbId& id) {
+  return id.traffic_light_id().string();
+}
+
+rust::String UniqueBulbId_bulb_group_id(const UniqueBulbId& id) {
+  return id.bulb_group_id().string();
+}
+
+rust::String UniqueBulbId_bulb_id(const UniqueBulbId& id) {
+  return id.bulb_id().string();
+}
+
+rust::String UniqueBulbGroupId_traffic_light_id(const UniqueBulbGroupId& id) {
+  return id.traffic_light_id().string();
+}
+
+rust::String UniqueBulbGroupId_bulb_group_id(const UniqueBulbGroupId& id) {
+  return id.bulb_group_id().string();
 }
 
 }  // namespace rules

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -175,8 +175,10 @@ pub struct Bulb<'a> {
 
 impl Bulb<'_> {
     /// Returns this Bulb instance's unique identifier.
-    pub fn unique_id(&self) -> String {
-        unimplemented!()
+    pub fn unique_id(&self) -> UniqueBulbId {
+        UniqueBulbId {
+            unique_bulb_id: maliput_sys::api::rules::ffi::Bulb_unique_id(self.bulb),
+        }
     }
 
     /// Get the id of the [Bulb].
@@ -333,8 +335,10 @@ pub struct BulbGroup<'a> {
 
 impl BulbGroup<'_> {
     /// Returns this BulbGroup instance's unique identifier.
-    pub fn unique_id(&self) -> String {
-        unimplemented!()
+    pub fn unique_id(&self) -> UniqueBulbGroupId {
+        UniqueBulbGroupId {
+            unique_bulb_group_id: maliput_sys::api::rules::ffi::BulbGroup_unique_id(self.bulb_group),
+        }
     }
 
     /// Get the id of the [BulbGroup].
@@ -401,5 +405,78 @@ impl BulbGroup<'_> {
                     .expect("Unable to get underlying traffic light pointer. The BulbGroup might not be registered to a TrafficLight.")
             },
         }
+    }
+}
+
+/// Uniquely identifies a bulb in the `Inertial` space. This consists of the
+/// concatenation of the bulb's ID, the ID of the bulb group that contains the
+/// bulb, and the the ID of the traffic light that contains the bulb group.
+///
+/// String representation of this ID is:
+/// "`traffic_light_id().string()`-`bulb_group_id.string()`-`bulb_id.string()`"
+pub struct UniqueBulbId {
+    unique_bulb_id: cxx::UniquePtr<maliput_sys::api::rules::ffi::UniqueBulbId>,
+}
+
+impl UniqueBulbId {
+    /// Get the traffic light id of the [UniqueBulbId].
+    /// ## Return
+    /// The traffic light id of the [UniqueBulbId].
+    pub fn traffic_light_id(&self) -> String {
+        maliput_sys::api::rules::ffi::UniqueBulbId_traffic_light_id(&self.unique_bulb_id)
+    }
+
+    /// Get the bulb group id of the [UniqueBulbId].
+    /// ## Return
+    /// The bulb group id of the [UniqueBulbId].
+    pub fn bulb_group_id(&self) -> String {
+        maliput_sys::api::rules::ffi::UniqueBulbId_bulb_group_id(&self.unique_bulb_id)
+    }
+
+    /// Get the bulb id of the [UniqueBulbId].
+    /// ## Return
+    /// The bulb id of the [UniqueBulbId].
+    pub fn bulb_id(&self) -> String {
+        maliput_sys::api::rules::ffi::UniqueBulbId_bulb_id(&self.unique_bulb_id)
+    }
+
+    /// Get the string representation of the [UniqueBulbId].
+    /// ## Return
+    /// The string representation of the [UniqueBulbId].
+    pub fn string(&self) -> String {
+        self.unique_bulb_id.string().to_string()
+    }
+}
+
+/// Uniquely identifies a bulb group in the `Inertial` space. This consists of
+/// the concatenation of the ID of the bulb group, and the ID of the traffic
+/// light that contains the bulb group.
+///
+/// String representation of this ID is:
+/// "`traffic_light_id().string()`-`bulb_group_id.string()`"
+pub struct UniqueBulbGroupId {
+    unique_bulb_group_id: cxx::UniquePtr<maliput_sys::api::rules::ffi::UniqueBulbGroupId>,
+}
+
+impl UniqueBulbGroupId {
+    /// Get the traffic light id of the [UniqueBulbGroupId].
+    /// ## Return
+    /// The traffic light id of the [UniqueBulbGroupId].
+    pub fn traffic_light_id(&self) -> String {
+        maliput_sys::api::rules::ffi::UniqueBulbGroupId_traffic_light_id(&self.unique_bulb_group_id)
+    }
+
+    /// Get the bulb group id of the [UniqueBulbGroupId].
+    /// ## Return
+    /// The bulb group id of the [UniqueBulbGroupId].
+    pub fn bulb_group_id(&self) -> String {
+        maliput_sys::api::rules::ffi::UniqueBulbGroupId_bulb_group_id(&self.unique_bulb_group_id)
+    }
+
+    /// Get the string representation of the [UniqueBulbGroupId].
+    /// ## Return
+    /// The string representation of the [UniqueBulbGroupId].
+    pub fn string(&self) -> String {
+        self.unique_bulb_group_id.string().to_string()
     }
 }

--- a/maliput/tests/traffic_light_tests.rs
+++ b/maliput/tests/traffic_light_tests.rs
@@ -81,6 +81,17 @@ fn bulb_group_test_api() {
     assert_eq!(bulb_groups.len(), 1);
     let bulb_group = bulb_groups.first().expect("No bulb groups found");
     assert_eq!(bulb_group.id(), "EastFacingBulbs");
+
+    // UniqueBulbGroupId tests.
+    let unique_id = bulb_group.unique_id();
+    let traffic_light_id = unique_id.traffic_light_id();
+    assert_eq!(traffic_light_id, traffic_light.id());
+    let bulb_group_id = unique_id.bulb_group_id();
+    assert_eq!(bulb_group_id, bulb_group.id());
+    let bulb_group_unique_id = unique_id.string();
+    assert_eq!(bulb_group_unique_id, "EastFacing-EastFacingBulbs");
+
+    // BulbGroups pose tests.
     let position_traffic_light = bulb_group.position_traffic_light();
     assert_eq!(position_traffic_light.x(), 0.0);
     assert_eq!(position_traffic_light.y(), 0.0);
@@ -92,6 +103,7 @@ fn bulb_group_test_api() {
     let bulbs = bulb_group.bulbs();
     assert_eq!(bulbs.len(), 4);
 
+    // BulbGroup get api.
     let bulb = bulb_group.get_bulb(&String::from("RedBulb"));
     assert!(bulb.is_some());
     let position_bulb = bulb.unwrap().position_bulb_group();
@@ -123,6 +135,17 @@ fn bulb_test_api() {
     let traffic_light = book.get_traffic_light(&String::from("EastFacing")).unwrap();
     let bulb_group = traffic_light.get_bulb_group(&String::from("EastFacingBulbs")).unwrap();
     let bulb = bulb_group.get_bulb(&String::from("RedBulb")).unwrap();
+
+    // UniqueBulbId tests.
+    let unique_id = bulb.unique_id();
+    let traffic_light_id = unique_id.traffic_light_id();
+    assert_eq!(traffic_light_id, traffic_light.id());
+    let bulb_group_id = unique_id.bulb_group_id();
+    assert_eq!(bulb_group_id, bulb_group.id());
+    let bulb_id = unique_id.bulb_id();
+    assert_eq!(bulb_id, bulb.id());
+    let bulb_unique_id = unique_id.string();
+    assert_eq!(bulb_unique_id, "EastFacing-EastFacingBulbs-RedBulb");
 
     // Test on red bulb.
     assert_eq!(bulb.id(), "RedBulb");


### PR DESCRIPTION
# 🎉 New feature

Related to 
- https://github.com/maliput/maliput-rs/issues/99
- https://github.com/maliput/maliput-rs/issues/100
- https://github.com/maliput/maliput-rs/issues/102
- https://github.com/maliput/maliput-rs/issues/103

## Summary
 - Adds UniqueBulbId and UniqueBulbGroupId abstractions
 - Adds bindings to unique_id method of Bulb and BulbGroup abstractions


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
