### PR TITLE
FFI: Adds DiscreteValueRule bindings.

### DIFF
--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -36,6 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/api/api.h");
     println!("cargo:rerun-if-changed=src/api/mod.rs");
+    println!("cargo:rerun-if-changed=src/api/rules/aliases.h");
     println!("cargo:rerun-if-changed=src/api/rules/rules.h");
     println!("cargo:rerun-if-changed=src/api/rules/mod.rs");
     println!("cargo:rerun-if-changed=src/lib.rs");

--- a/maliput-sys/src/api/rules/aliases.h
+++ b/maliput-sys/src/api/rules/aliases.h
@@ -1,0 +1,45 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+#include <maliput/api/rules/discrete_value_rule.h>
+
+#include <memory>
+#include <vector>
+
+namespace maliput {
+namespace api {
+namespace rules {
+
+// Workaround for supporting nested types: https://github.com/dtolnay/cxx/issues/1198
+using DiscreteValueRuleDiscreteValue = DiscreteValueRule::DiscreteValue;
+
+}  // namespace rules
+}  // namespace api
+}  // namespace maliput

--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -55,6 +55,22 @@ pub mod ffi {
     struct FloatWrapper {
         pub value: f64,
     }
+    /// Shared struct for pairs in a RelatedRules collection.
+    ///  - key: Group name of the rules.
+    ///  - value: Rule ids.
+    /// This is needed because maps can't be binded directly.
+    struct RelatedRule {
+        pub group_name: String,
+        pub rule_ids: Vec<String>,
+    }
+    /// Shared struct for pairs in a RelatedRules collection.
+    ///  - key: Group name.
+    ///  - value: Unique Ids.
+    /// This is needed because maps can't be binded directly.
+    struct RelatedUniqueId {
+        pub group_name: String,
+        pub unique_id: Vec<String>,
+    }
 
     #[repr(i32)]
     enum BulbColor {
@@ -78,6 +94,7 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("api/rules/rules.h");
+        include!("api/rules/aliases.h");
 
         // Forward declarations
         #[namespace = "maliput::api"]
@@ -142,5 +159,20 @@ pub mod ffi {
         fn string(self: &UniqueBulbGroupId) -> &CxxString;
         fn UniqueBulbGroupId_traffic_light_id(id: &UniqueBulbGroupId) -> String;
         fn UniqueBulbGroupId_bulb_group_id(id: &UniqueBulbGroupId) -> String;
+
+        // DiscreteValueRule::DiscreteValue bindings definitions.
+        type DiscreteValueRuleDiscreteValue;
+        fn DiscreteValueRuleDiscreteValue_value(value: &DiscreteValueRuleDiscreteValue) -> String;
+        fn DiscreteValueRuleDiscreteValue_severity(value: &DiscreteValueRuleDiscreteValue) -> i32;
+        fn DiscreteValueRuleDiscreteValue_related_rules(
+            value: &DiscreteValueRuleDiscreteValue,
+        ) -> UniquePtr<CxxVector<RelatedRule>>;
+        fn DiscreteValueRuleDiscreteValue_related_unique_ids(
+            value: &DiscreteValueRuleDiscreteValue,
+        ) -> UniquePtr<CxxVector<RelatedUniqueId>>;
+
+        // DiscreteValueRule bindings definitions.
+        type DiscreteValueRule;
+        fn states(self: &DiscreteValueRule) -> &CxxVector<DiscreteValueRuleDiscreteValue>;
     }
 }

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -185,6 +185,38 @@ rust::String UniqueBulbGroupId_bulb_group_id(const UniqueBulbGroupId& id) {
   return id.bulb_group_id().string();
 }
 
+rust::String DiscreteValueRuleDiscreteValue_value(const DiscreteValueRuleDiscreteValue& discrete_value) {
+  return rust::String(discrete_value.value);
+}
+
+rust::i32 DiscreteValueRuleDiscreteValue_severity(const DiscreteValueRuleDiscreteValue& discrete_value) {
+  return discrete_value.severity;
+}
+
+std::unique_ptr<std::vector<RelatedRule>> DiscreteValueRuleDiscreteValue_related_rules(const DiscreteValueRuleDiscreteValue& discrete_value) {
+  std::vector<RelatedRule> related_rules;
+  for (const auto& related_rule : discrete_value.related_rules) {
+    rust::Vec<rust::String> rule_ids;
+    for (const auto& rule_id : related_rule.second) {
+      rule_ids.push_back({rule_id.string()});
+    }
+    related_rules.push_back({related_rule.first, rule_ids});
+  }
+  return std::make_unique<std::vector<RelatedRule>>(std::move(related_rules));
+}
+
+std::unique_ptr<std::vector<RelatedUniqueId>> DiscreteValueRuleDiscreteValue_related_unique_ids(const DiscreteValueRuleDiscreteValue& discrete_value) {
+  std::vector<RelatedUniqueId> related_unique_ids;
+  for (const auto& related_unique_id : discrete_value.related_unique_ids) {
+    rust::Vec<rust::String> unique_ids;
+    for (const auto& rule_id : related_unique_id.second) {
+      unique_ids.push_back({rule_id.string()});
+    }
+    related_unique_ids.push_back({related_unique_id.first, unique_ids});
+  }
+  return std::make_unique<std::vector<RelatedUniqueId>>(std::move(related_unique_ids));
+}
+
 }  // namespace rules
 }  // namespace api
 }  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Closes #<NUMBER>

## Summary
- Adds FFI bindings for DiscreteValueRule::DiscreteValue
  - An alias had to be generated at an FFI level in order to be able to create bindings for nested classes. 
- Adds FFI bindings for DiscreteValueRule


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
