### PR TITLE
Adds LaneSRoute bindings.

### DIFF
--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -296,6 +296,15 @@ std::unique_ptr<LaneSRange> LaneSRange_GetIntersection(const LaneSRange& lane_s_
   return nullptr;
 }
 
+std::unique_ptr<LaneSRoute> LaneSRoute_new(const std::vector<ConstLaneSRangeRef>& lane_s_ranges) {
+  std::vector<LaneSRange> lane_s_ranges_cpp;
+  lane_s_ranges_cpp.reserve(lane_s_ranges.size());
+  for (const auto& lane_s_range : lane_s_ranges) {
+    lane_s_ranges_cpp.push_back(LaneSRange{lane_s_range.lane_s_range.lane_id(), lane_s_range.lane_s_range.s_range()});
+  }
+  return std::make_unique<LaneSRoute>(lane_s_ranges_cpp);
+}
+
 std::unique_ptr<LaneEnd> LaneEnd_new(const Lane* lane, bool start) {
   return std::make_unique<LaneEnd>(lane, start ? LaneEnd::kStart : LaneEnd::kFinish);
 }

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -42,6 +42,11 @@ pub mod ffi {
     struct MutIntersectionPtr {
         pub intersection: *mut Intersection,
     }
+    /// Shared struct for `LaneSRange` references.
+    /// This is needed because `&f` can't be used directly in the CxxVector collection.
+    struct ConstLaneSRangeRef<'a> {
+        pub lane_s_range: &'a LaneSRange,
+    }
 
     unsafe extern "C++" {
         include!("api/api.h");
@@ -232,6 +237,13 @@ pub mod ffi {
             other: &LaneSRange,
             tolerance: f64,
         ) -> UniquePtr<LaneSRange>;
+
+        // LaneSRoute bindings definitions
+        type LaneSRoute;
+        fn LaneSRoute_new(ranges: &CxxVector<ConstLaneSRangeRef>) -> UniquePtr<LaneSRoute>;
+        fn length(self: &LaneSRoute) -> f64;
+        fn Intersects(self: &LaneSRoute, other: &LaneSRoute, tolerance: f64) -> bool;
+        fn ranges(self: &LaneSRoute) -> &CxxVector<LaneSRange>;
 
         // LaneEnd bindings definitions
         type LaneEnd;

--- a/maliput-sys/tests/api_tests.rs
+++ b/maliput-sys/tests/api_tests.rs
@@ -353,4 +353,40 @@ mod api_test {
             assert_eq!(s_range.s1(), 2.0);
         }
     }
+
+    mod lane_s_route_test {
+        use maliput_sys::api::ffi::ConstLaneSRangeRef;
+        use maliput_sys::api::ffi::LaneSRange_lane_id;
+        use maliput_sys::api::ffi::LaneSRange_new;
+        use maliput_sys::api::ffi::LaneSRoute_new;
+        use maliput_sys::api::ffi::SRange_new;
+        #[test]
+        fn lane_s_route_api() {
+            let s_range = SRange_new(1.0, 2.0);
+            let lane_id = String::from("0_0_1");
+            let lane_s_range_1 = LaneSRange_new(&lane_id, &s_range);
+            let lane_id = String::from("1_0_1");
+            let lane_s_range_2 = LaneSRange_new(&lane_id, &s_range);
+
+            let mut v = cxx::CxxVector::new();
+            v.as_mut().unwrap().push(ConstLaneSRangeRef {
+                lane_s_range: &lane_s_range_1,
+            });
+            v.as_mut().unwrap().push(ConstLaneSRangeRef {
+                lane_s_range: &lane_s_range_2,
+            });
+            let lane_s_route = LaneSRoute_new(&v);
+            assert!(!lane_s_route.is_null());
+            // Ranges
+            let ranges = lane_s_route.ranges();
+            assert_eq!(ranges.len(), 2);
+            assert_eq!(LaneSRange_lane_id(ranges.get(0).expect("")), "0_0_1");
+            assert_eq!(LaneSRange_lane_id(ranges.get(1).expect("")), "1_0_1");
+            // Length
+            assert_eq!(lane_s_route.length(), 2.0);
+            // Intersects
+            let lane_s_route_b = LaneSRoute_new(&v);
+            assert!(lane_s_route.Intersects(&lane_s_route_b, 1e-3));
+        }
+    }
 }


### PR DESCRIPTION
# 🎉 New feature

Related to:
 - https://github.com/maliput/maliput-rs/issues/28
 - https://github.com/maliput/maliput-rs/issues/17

## Summary
 - LaneSRoute bindings



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
