### PR TITLE
Adds GenerateObjFile bindings.

### DIFF
--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -44,6 +44,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=src/math/mod.rs");
     println!("cargo:rerun-if-changed=src/plugin/mod.rs");
     println!("cargo:rerun-if-changed=src/plugin/plugin.h");
+    println!("cargo:rerun-if-changed=src/utility/mod.rs");
+    println!("cargo:rerun-if-changed=src/utility/utility.h");
 
     let maliput_bin_path =
         PathBuf::from(env::var("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH").expect("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH not set"));
@@ -63,6 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     cxx_build::bridges([
         "src/math/mod.rs",
+        "src/utility/mod.rs",
         "src/api/rules/mod.rs",
         "src/api/mod.rs",
         "src/plugin/mod.rs",

--- a/maliput-sys/src/utility/mod.rs
+++ b/maliput-sys/src/utility/mod.rs
@@ -1,0 +1,100 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[cxx::bridge(namespace = "maliput::utility")]
+pub mod ffi {
+
+    pub struct Features {
+        /// Maximum distance between rendered vertices, in either s- or r-dimension,
+        /// along a lane's surface
+        pub max_grid_unit: f64,
+        /// Minimum number of vertices, in either s- or r-dimension, along a lane's
+        /// surface.
+        pub min_grid_resolution: f64,
+        /// Draw stripes along lane_bounds() of each lane?
+        pub draw_stripes: bool,
+        /// Draw arrows at start/finish of each lane?
+        pub draw_arrows: bool,
+        /// Draw highlighting swath with lane_bounds() of each lane?
+        pub draw_lane_haze: bool,
+        /// Draw branching at BranchPoints?
+        pub draw_branch_points: bool,
+        /// Draw highlighting of elevation_bounds of each lane?
+        pub draw_elevation_bounds: bool,
+        /// Reduce the amount of vertices from the road by creating
+        /// quads big enough which don't violate some tolerance. This could affect
+        /// the accuracy of curved roads.
+        pub off_grid_mesh_generation: bool,
+        /// Tolerance for mesh simplification, or the distance from a vertex to an
+        /// edge line or to a face plane at which said vertex is considered redundant
+        /// (i.e. it is not necessary to further define those geometrical entities),
+        /// in meters. If equal to 0, no mesh simplification will take place. If equal
+        /// to the road linear tolerance, mesh simplification will be constrained
+        /// enough so as to keep mesh geometrical accuracy. If greater than the road
+        /// linear tolerance, mesh size reductions will come at the expense of
+        /// geometrical accuracy.
+        pub simplify_mesh_threshold: f64,
+        /// Absolute width of stripes
+        pub stripe_width: f64,
+        /// Absolute elevation (h) of stripes above road surface
+        pub stripe_elevation: f64,
+        /// Absolute elevation (h) of arrows above road surface
+        pub arrow_elevation: f64,
+        /// Absolute elevation (h) of lane-haze above road surface
+        pub lane_haze_elevation: f64,
+        /// Absolute elevation (h) of branch-points above road surface
+        pub branch_point_elevation: f64,
+        /// Height of rendered branch-point arrows
+        pub branch_point_height: f64,
+        /// Origin of OBJ coordinates relative to `Inertial`-frame
+        pub origin: [f64; 3],
+        /// ID's of specific segments to be highlighted.  (If non-empty, then the
+        /// Segments *not* specified on this list will be rendered as grayed-out.)
+        pub highlighted_segments: Vec<String>,
+    }
+    unsafe extern "C++" {
+        include!("utility/utility.h");
+
+        #[namespace = "maliput::api"]
+        type RoadNetwork = crate::api::ffi::RoadNetwork;
+
+        /// Generates an .obj and .mtl files named `fileroot` under the `dirpath` directory.
+        ///
+        /// # Safety
+        ///
+        /// The caller must ensure the `road_network` pointer is valid during the method execution.
+        unsafe fn Utility_GenerateObjFile(
+            road_network: *const RoadNetwork,
+            dirpath: &String,
+            fileroot: &String,
+            features: &Features,
+        );
+    }
+}

--- a/maliput-sys/src/utility/utility.h
+++ b/maliput-sys/src/utility/utility.h
@@ -1,0 +1,76 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <rust/cxx.h>
+
+#include <string>
+
+#include "maliput/api/road_network.h"
+#include "maliput/utility/generate_obj.h"
+
+#include "maliput-sys/src/utility/mod.rs.h"
+
+namespace maliput {
+namespace utility {
+
+/// Creates a wrapper around maliput::utility::GenerateObjFile.
+void Utility_GenerateObjFile(const maliput::api::RoadNetwork* road_network,
+                                 const rust::String& dirpath,
+                                 const rust::String& fileroot,
+                                 const Features& features) {
+
+  struct ObjFeatures objFeatures = {};
+  objFeatures.max_grid_unit = features.max_grid_unit;
+  objFeatures.min_grid_resolution = features.min_grid_resolution;
+  objFeatures.draw_stripes = features.draw_stripes;
+  objFeatures.draw_arrows = features.draw_arrows;
+  objFeatures.draw_lane_haze = features.draw_lane_haze;
+  objFeatures.draw_branch_points = features.draw_branch_points;
+  objFeatures.draw_elevation_bounds = features.draw_elevation_bounds;
+  objFeatures.off_grid_mesh_generation = features.off_grid_mesh_generation;
+  objFeatures.simplify_mesh_threshold = features.simplify_mesh_threshold;
+  objFeatures.stripe_width = features.stripe_width;
+  objFeatures.stripe_elevation = features.stripe_elevation;
+  objFeatures.arrow_elevation = features.arrow_elevation;
+  objFeatures.lane_haze_elevation = features.lane_haze_elevation;
+  objFeatures.branch_point_elevation = features.branch_point_elevation;
+  objFeatures.branch_point_height = features.branch_point_height;
+  objFeatures.origin = api::InertialPosition{features.origin[0], features.origin[1], features.origin[2]};
+
+  maliput::utility::GenerateObjFile(road_network, std::string(dirpath),
+                                    std::string(fileroot), objFeatures);
+}
+
+
+}  // namespace utility
+}  // namespace maliput

--- a/maliput-sys/tests/resources/ArcLane.xodr
+++ b/maliput-sys/tests/resources/ArcLane.xodr
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2022, Woven Planet. All rights reserved.
+ Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="SingleLane" version="1.00" date="Wed Sep 19 12:00:00 2018" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="" length="100.0" id="1" junction="-1">
+        <link>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
+                <arc curvature="0.025"/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/maliput-sys/tests/utility_tests.rs
+++ b/maliput-sys/tests/utility_tests.rs
@@ -1,0 +1,94 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[cfg(test)]
+mod utility_test {
+    mod generate_obj_file_test {
+        use cxx::UniquePtr;
+        use maliput_sys::api::ffi::RoadNetwork;
+        use maliput_sys::plugin::ffi::CreateRoadNetwork;
+        use maliput_sys::utility::ffi::Features;
+        use maliput_sys::utility::ffi::Utility_GenerateObjFile;
+        use std::fs::{create_dir, metadata, remove_dir_all};
+        use std::path::PathBuf;
+
+        fn setup_road_network() -> UniquePtr<RoadNetwork> {
+            std::env::set_var("MALIPUT_PLUGIN_PATH", maliput_sdk::get_maliput_malidrive_plugin_path());
+            let road_network_loader_id = String::from("maliput_malidrive");
+            let package_location = env!("CARGO_MANIFEST_DIR");
+            let xodr_path = format!("opendrive_file:{}/tests/resources/ArcLane.xodr", package_location);
+            let road_network_properties = vec![xodr_path];
+
+            CreateRoadNetwork(&road_network_loader_id, &road_network_properties)
+        }
+
+        #[test]
+        fn generate_obj_file() {
+            let obj_features = Features {
+                max_grid_unit: 1.0,
+                min_grid_resolution: 5.0,
+                draw_stripes: true,
+                draw_arrows: true,
+                draw_lane_haze: true,
+                draw_branch_points: true,
+                draw_elevation_bounds: true,
+                off_grid_mesh_generation: false,
+                simplify_mesh_threshold: 0.,
+                stripe_width: 0.25,
+                stripe_elevation: 0.05,
+                arrow_elevation: 0.05,
+                lane_haze_elevation: 0.02,
+                branch_point_elevation: 0.5,
+                branch_point_height: 0.5,
+                origin: [0.; 3],
+                highlighted_segments: Vec::new(),
+            };
+            let road_network = setup_road_network();
+            let out_dir = std::env::temp_dir().join("maliput");
+            if out_dir.exists() {
+                let _ = remove_dir_all(&out_dir);
+            }
+            let _ = create_dir(&out_dir);
+
+            let out_dir = out_dir.as_os_str().to_str().unwrap().to_string();
+            let file_root = String::from("road_network");
+            unsafe {
+                Utility_GenerateObjFile(road_network.as_ref().unwrap(), &out_dir, &file_root, &obj_features);
+            }
+            let file_path = PathBuf::from(&out_dir).join(file_root + ".obj");
+            let metadata = metadata(file_path).unwrap();
+
+            // Check that the file is not empty.
+            assert_ne!(metadata.len(), 0);
+
+            let _ = remove_dir_all(out_dir);
+        }
+    }
+}

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -200,7 +200,7 @@ impl<'a> RoadGeometry<'a> {
 /// println!("num_junctions: {}", road_geometry.num_junctions());
 /// ```
 pub struct RoadNetwork {
-    rn: cxx::UniquePtr<maliput_sys::api::ffi::RoadNetwork>,
+    pub(crate) rn: cxx::UniquePtr<maliput_sys::api::ffi::RoadNetwork>,
 }
 
 impl RoadNetwork {

--- a/maliput/src/lib.rs
+++ b/maliput/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod api;
 pub mod math;
+pub mod utility;
 
 /// ### ResourceManager
 ///

--- a/maliput/src/utility/mod.rs
+++ b/maliput/src/utility/mod.rs
@@ -27,10 +27,49 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#![allow(rustdoc::bare_urls)]
-#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-pub mod api;
-pub mod math;
-pub mod plugin;
-pub mod utility;
+use maliput_sys::api::ffi::RoadNetwork;
+use std::error::Error;
+use std::fs::{read_to_string, remove_file};
+use std::path::Path;
+
+type Features = maliput_sys::utility::ffi::Features;
+
+// Generate a mesh obj file from the road network.
+pub fn generate_obj_file(road_network: &RoadNetwork, dirpath: &String, fileroot: &String, features: &Features) {
+    unsafe {
+        maliput_sys::utility::ffi::Utility_GenerateObjFile(road_network, dirpath, fileroot, features);
+    }
+}
+
+pub fn get_obj_description_from_road_network(
+    road_network: &RoadNetwork,
+    output_directory: String,
+) -> Result<String, Box<dyn Error>> {
+    let file_name = String::from("road_network");
+    let features = Features {
+        max_grid_unit: 1.0,
+        min_grid_resolution: 5.0,
+        draw_stripes: true,
+        draw_arrows: true,
+        draw_lane_haze: true,
+        draw_branch_points: true,
+        draw_elevation_bounds: true,
+        off_grid_mesh_generation: false,
+        simplify_mesh_threshold: 0.,
+        stripe_width: 0.25,
+        stripe_elevation: 0.05,
+        arrow_elevation: 0.05,
+        lane_haze_elevation: 0.02,
+        branch_point_elevation: 0.5,
+        branch_point_height: 0.5,
+        origin: [0.; 3],
+        highlighted_segments: Vec::new(),
+    };
+    generate_obj_file(road_network, &output_directory, &file_name, &features);
+    let full_path = Path::new(&output_directory);
+    let full_path = full_path.join(file_name + ".obj");
+    let obj_description = read_to_string(&full_path)?;
+    let _ = remove_file(full_path);
+    Ok(obj_description)
+}

--- a/maliput/tests/obj_file_description_test.rs
+++ b/maliput/tests/obj_file_description_test.rs
@@ -1,0 +1,31 @@
+mod common;
+
+use maliput::utility::{get_obj_description_from_road_network, Features};
+
+#[test]
+fn get_obj_description_from_road_network_test() {
+    let road_network = common::create_t_shape_road_network();
+    let features = Features {
+        max_grid_unit: 1.0,
+        min_grid_resolution: 5.0,
+        draw_stripes: true,
+        draw_arrows: true,
+        draw_lane_haze: true,
+        draw_branch_points: true,
+        draw_elevation_bounds: true,
+        off_grid_mesh_generation: false,
+        simplify_mesh_threshold: 0.,
+        stripe_width: 0.25,
+        stripe_elevation: 0.05,
+        arrow_elevation: 0.05,
+        lane_haze_elevation: 0.02,
+        branch_point_elevation: 0.5,
+        branch_point_height: 0.5,
+        origin: [0.; 3],
+        highlighted_segments: Vec::new(),
+    };
+    let obj_description = get_obj_description_from_road_network(&road_network, &features);
+    assert!(obj_description.is_ok());
+    let obj_description = obj_description.unwrap();
+    assert_ne!(obj_description.len(), 0);
+}


### PR DESCRIPTION
# 🎉 New feature

Related to #124 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
* Rust API bindings for GenerateObjFile method.
* Adds `get_obj_description_for_road_network` method.
  * This method is a wrapper for `generate_obj_file` that returns the content of the file in a `String`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
