### PR TITLE
Provides binding for RoadGeometry::BackendCustomCommand method.

### DIFF
--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.3.1")
-bazel_dep(name = "maliput_malidrive", version = "0.3.1")
+bazel_dep(name = "maliput", version = "1.4.0")
+bazel_dep(name = "maliput_malidrive", version = "0.4.0")

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -65,7 +65,7 @@ fn get_bazel_library_version(library_name: &str) -> String {
     let line_index: usize = process_output_lines
         .position(|line| line.contains(&library_token))
         .expect("Couldn't find the library");
-    let library_version: &str = process_output
+    let mut library_version: &str = process_output
         .lines()
         .nth(line_index)
         .expect("Failed to retrieve the line from the process output.")
@@ -73,6 +73,10 @@ fn get_bazel_library_version(library_name: &str) -> String {
         .last()
         .expect("Failed to retrieve library version.")
         .trim(); // Remove trailing spaces.
+    if library_version == "_" {
+        // Support the case when "local_path_override" is used for the modules.
+        library_version = "override";
+    }
     String::from(library_version)
 }
 

--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -232,6 +232,10 @@ const Junction* RoadGeometry_GetJunction(const RoadGeometry& road_geometry, cons
   return road_geometry.ById().GetJunction(JunctionId{std::string(junction_id)});
 }
 
+rust::String RoadGeometry_BackendCustomCommand(const RoadGeometry& road_geometry, const rust::String& command) {
+  return road_geometry.BackendCustomCommand(std::string(command));
+}
+
 std::unique_ptr<Rotation> Rotation_new() {
   return std::make_unique<Rotation>();
 }

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -88,6 +88,7 @@ pub mod ffi {
         fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
         fn RoadGeometry_GetJunction(rg: &RoadGeometry, junction_id: &String) -> *const Junction;
         fn RoadGeometry_GetBranchPoint(rg: &RoadGeometry, branch_point_id: &String) -> *const BranchPoint;
+        fn RoadGeometry_BackendCustomCommand(rg: &RoadGeometry, command: &String) -> String;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -23,3 +23,7 @@ criterion = { version = "0.4", features = ["html_reports"] }
 [[bench]]
 name = "to_road_position"
 harness = false
+
+[[bench]]
+name = "backend_custom_command"
+harness = false

--- a/maliput/benches/backend_custom_command/main.rs
+++ b/maliput/benches/backend_custom_command/main.rs
@@ -1,0 +1,58 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use maliput::api::RoadNetwork;
+use std::collections::HashMap;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // Get location of odr resources
+    let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let xodr_path = format!("{}/data/xodr/Town01.xodr", package_location);
+
+    let road_network_properties = HashMap::from([
+        ("road_geometry_id", "my_rg_from_rust"),
+        ("opendrive_file", xodr_path.as_str()),
+        ("linear_tolerance", "0.01"),
+    ]);
+    let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties);
+    let road_geometry = road_network.road_geometry();
+
+    let command = "OpenScenarioRoadPositionToMaliputRoadPosition,3,30,-1."; // <command>/<road_id>/<s>/<t>
+    c.bench_function("RoadGeometry::backend_custom_command", |b| {
+        b.iter(|| {
+            let _command_res = road_geometry.backend_custom_command(&command.to_string());
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/maliput/data/xodr/ArcLane.xodr
+++ b/maliput/data/xodr/ArcLane.xodr
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ BSD 3-Clause License
+
+ Copyright (c) 2022, Woven Planet. All rights reserved.
+ Copyright (c) 2020-2022, Toyota Research Institute. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<OpenDRIVE>
+    <header revMajor="1" revMinor="1" name="SingleLane" version="1.00" date="Wed Sep 19 12:00:00 2018" north="0.0000000000000000e+00" south="0.0000000000000000e+00" east="0.0000000000000000e+00" west="0.0000000000000000e+00" maxRoad="2" maxJunc="0" maxPrg="0">
+    </header>
+    <road name="" length="100.0" id="1" junction="-1">
+        <link>
+        </link>
+        <planView>
+            <geometry s="0.0000000000000000e+00" x="0.0" y="0.0" hdg="0.0" length="100.0">
+                <arc curvature="0.025"/>
+            </geometry>
+        </planView>
+        <elevationProfile>
+        </elevationProfile>
+        <lateralProfile>
+        </lateralProfile>
+        <lanes>
+            <laneSection s="0.0000000000000000e+00">
+                <left>
+                    <lane id="1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </left>
+                <center>
+                    <lane id="0" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <roadMark sOffset="0.0000000000000000e+00" type="broken" weight="standard" color="standard" width="1.3000000000000000e-01"/>
+                    </lane>
+                </center>
+                <right>
+                    <lane id="-1" type="driving" level= "0">
+                        <link>
+                        </link>
+                        <width sOffset="0.0000000000000000e+00" a="2.0" b="0.0000000000000000e+00" c="0.0000000000000000e+00" d="0.0000000000000000e+00"/>
+                        <roadMark sOffset="0.0000000000000000e+00" type="solid" weight="standard" color="standard" width="1.0000000000000000e-01"/>
+                    </lane>
+                </right>
+            </laneSection>
+        </lanes>
+        <objects>
+        </objects>
+        <signals>
+        </signals>
+    </road>
+</OpenDRIVE>

--- a/maliput/examples/backend_custom_command.rs
+++ b/maliput/examples/backend_custom_command.rs
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+fn main() {
+    use maliput::api::RoadNetwork;
+    use std::collections::HashMap;
+
+    // Get location of odr resources
+    let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let xodr_path = format!("{}/data/xodr/Town01.xodr", package_location);
+
+    let road_network_properties = HashMap::from([
+        ("road_geometry_id", "my_rg_from_rust"),
+        ("opendrive_file", xodr_path.as_str()),
+    ]);
+
+    let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties);
+    let road_geometry = road_network.road_geometry();
+
+    let command = "OpenScenarioRoadPositionToMaliputRoadPosition,3,30,-1."; // <command>/<road_id>/<s>/<t>
+    let command_res = road_geometry.backend_custom_command(&command.to_string());
+    println!("Command: {:?}", command);
+    println!("Command result: {:?}", command_res);
+}

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -181,6 +181,18 @@ impl<'a> RoadGeometry<'a> {
             }
         }
     }
+    /// Execute a custom command on the backend.
+    /// ### Details
+    /// The documentation of the custom command should be provided by the backend: https://github.com/maliput/maliput_malidrive/blob/main/src/maliput_malidrive/base/road_geometry.h
+    ///
+    /// ### Arguments
+    /// * `command` - The command to execute.
+    ///
+    /// ### Return
+    /// The result of the command.
+    pub fn backend_custom_command(&self, command: &String) -> String {
+        maliput_sys::api::ffi::RoadGeometry_BackendCustomCommand(self.rg, command)
+    }
 }
 
 /// A RoadNetwork.

--- a/maliput/tests/common/mod.rs
+++ b/maliput/tests/common/mod.rs
@@ -46,6 +46,20 @@ pub fn create_t_shape_road_network() -> RoadNetwork {
 }
 
 #[allow(dead_code)]
+pub fn create_arc_lane_road_network() -> RoadNetwork {
+    // Get location of odr resources
+    let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let xodr_path = format!("{}/data/xodr/ArcLane.xodr", package_location);
+
+    let road_network_properties = HashMap::from([
+        ("road_geometry_id", "my_rg_from_rust"),
+        ("opendrive_file", xodr_path.as_str()),
+        ("linear_tolerance", "0.01"),
+    ]);
+    RoadNetwork::new("maliput_malidrive", &road_network_properties)
+}
+
+#[allow(dead_code)]
 pub fn create_t_shape_road_network_with_books() -> RoadNetwork {
     let rm = ResourceManager::new();
     let t_shape_xodr_path = rm

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -90,3 +90,16 @@ fn by_index() {
     let junction = road_geometry.get_junction(&junction_id);
     assert_eq!(junction.id(), "0_0");
 }
+
+#[test]
+fn backend_custom_command() {
+    let road_network = common::create_arc_lane_road_network();
+    let road_geometry = road_network.road_geometry();
+
+    let command = String::from("OpenScenarioLanePositionToMaliputRoadPosition,1,50,-1,0.");
+    let result = road_geometry.backend_custom_command(&command);
+    assert_eq!(result, "1_0_-1,51.250000,0.000000,0.000000");
+    let command = String::from("OpenScenarioRoadPositionToMaliputRoadPosition,1,50,0.");
+    let result = road_geometry.backend_custom_command(&command);
+    assert_eq!(result, "1_0_-1,51.250000,1.000000,0.000000");
+}


### PR DESCRIPTION
# 🎉 New feature

Relates to:
 - https://github.com/maliput/maliput/pull/643
 - https://github.com/maliput/maliput_malidrive/pull/289


## Important
This PR should go in after:
 - aforementioned PRs are merged
 - New BCR releases are made.
   - https://github.com/bazelbuild/bazel-central-registry/pull/3967
   - https://github.com/bazelbuild/bazel-central-registry/pull/3968

For the sake of this implementation I've worked locally by:
 - git cloning maliput and maliput_malidrive in the container
 - modifying the MODULE.bazel file for overriding the local path
```
local_path_override(module_name = "maliput", path = "../../maliput")
local_path_override(module_name = "maliput_malidrive", path = "../../maliput_malidrive")
``` 

## Summary

- Provides binding for RoadGeometry::BackendCustomCommand method.
- Add tests
- Add example
- Add benchmark to evaluate performance.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)


