### PR TITLE
Bump rustc version from 1.75 to 1.83

### DIFF
--- a/.devcontainer/rust-zen/Dockerfile
+++ b/.devcontainer/rust-zen/Dockerfile
@@ -15,7 +15,7 @@ FROM mcr.microsoft.com/devcontainers/base:${BASE_IMAGE}
 ################################################################################
 
 ARG BAZEL_VERSION=6.4.0
-ARG RUST_VERSION=1.75.0
+ARG RUST_VERSION=1.83.0
 
 ################################################################################
 # User 'zen'


### PR DESCRIPTION
# 🎉 New feature

## Summary
Upgrade `rustc` version from 1.75 to 1.83.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
