### PR TITLE
Update containers workflow to use rustc 1.83

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Image - Rust
       uses: docker/build-push-action@v6
       with:
-        context: devcontainer
+        context: ./.devcontainer
         file: ./.devcontainer/rust-zen/Dockerfile
         push: true
         build-args: |

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -43,7 +43,7 @@ jobs:
         echo "TAGS: ${{ steps.meta.outputs.tags }}"
         echo "LABELS: ${{ steps.meta.outputs.labels }}"
     - name: Image - Rust
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         file: ./.devcontainer/rust-zen/Dockerfile
         push: true

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -42,6 +42,8 @@ jobs:
         echo "REPOSITORY: ${{ github.repository }}"
         echo "TAGS: ${{ steps.meta.outputs.tags }}"
         echo "LABELS: ${{ steps.meta.outputs.labels }}"
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Image - Rust
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Image - Rust
       uses: docker/build-push-action@v6
       with:
+        context: ./devcontainer
         file: ./.devcontainer/rust-zen/Dockerfile
         push: true
         build-args: |

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Image - Rust
       uses: docker/build-push-action@v6
       with:
-        context: ./devcontainer
+        context: devcontainer
         file: ./.devcontainer/rust-zen/Dockerfile
         push: true
         build-args: |

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -6,7 +6,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-rust-ci
   BAZEL_VERSION: "6.4.0"
-  RUSTC_VERSION: "1.75.0"
+  RUSTC_VERSION: "1.83.0"
 
 on:
   push:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -42,8 +42,6 @@ jobs:
         echo "REPOSITORY: ${{ github.repository }}"
         echo "TAGS: ${{ steps.meta.outputs.tags }}"
         echo "LABELS: ${{ steps.meta.outputs.labels }}"
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Image - Rust
       uses: docker/build-push-action@v6
       with:


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Bumping `rustc` version in `containers` workflow so it matches the devcontainers `rustc` version.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

