### PR TITLE
Prepare for maliput-sdk release 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "maliput-sys"

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.1.9",
+    version = "0.1.10",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.4.0")
-bazel_dep(name = "maliput_malidrive", version = "0.4.3")
+bazel_dep(name = "maliput", version = "1.4.1")
+bazel_dep(name = "maliput_malidrive", version = "0.4.4")


### PR DESCRIPTION
# :balloon:  Release

DEpends on 
 - #150 

## Summary
maliput-sdk 0.1.10 release

## After merge

```
cargo publish --dry-run --verbose --package maliput-sdk
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
