### PR TITLE
maliput-sdk: prepare for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.1.10"
+version = "0.1.11"
 
 [[package]]
 name = "maliput-sys"

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.1.10",
+    version = "0.1.11",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")


### PR DESCRIPTION
# Release

## Summary
maliput-sdk 0.1.11 release

## After merge

```
cargo publish --dry-run --verbose --package maliput-sdk
```