### PR TITLE
Update maliput-sdk minor version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.1.11"
+version = "0.2.0"
 
 [[package]]
 name = "maliput-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "maliput",
-    "maliput-sdk",
-    "maliput-sys",
-]
+members = ["maliput", "maliput-sdk", "maliput-sys"]
 
 [workspace.package]
 edition = "2021"
@@ -13,5 +9,5 @@ license = "BSD-3-Clause"
 repository = "https://github.com/maliput/maliput-rs"
 
 [workspace.dependencies]
-maliput-sdk = { version = "0.1",  path = "maliput-sdk" }
+maliput-sdk = { version = "0.2", path = "maliput-sdk" }
 maliput-sys = { version = "0.1", path = "maliput-sys" }

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.1.11"
+version = "0.2.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.1.11",
+    version = "0.2.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")


### PR DESCRIPTION
# :balloon: Release

## Summary
`maliput-sdk` minor release, to 0.2.

## After Merge
`cargo publish --dry-run --verbose --package maliput-sdk`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
