### PR TITLE
Point to latest maliput BCR.

### DIFF
--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.4.2")
-bazel_dep(name = "maliput_malidrive", version = "0.5.0")
+bazel_dep(name = "maliput", version = "1.5.0")
+bazel_dep(name = "maliput_malidrive", version = "0.6.0")


### PR DESCRIPTION

## Summary
Points to `maliput` `1.5.0` and `maliput_malidrive` `0.6.0`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
