### PR TITLE
Prepare for maliput release 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maliput"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "cxx",
@@ -344,7 +344,7 @@ version = "0.2.0"
 
 [[package]]
 name = "maliput-sys"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/maliput/maliput-rs"
 
 [workspace.dependencies]
 maliput-sdk = { version = "0.2", path = "maliput-sdk" }
-maliput-sys = { version = "0.1", path = "maliput-sys" }
+maliput-sys = { version = "0.2", path = "maliput-sys" }

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sys"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "FFI Rust bindings for maliput"

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["simulation"]
 description = "Rust API for maliput"


### PR DESCRIPTION
# :balloon: Release

## Summary
Prepare release for `maliput` and `maliput-sys` `0.2` version.

## After merge
- [ ] ` cargo publish --dry-run --verbose --package maliput-sys`
- [ ] ` cargo publish --dry-run --verbose --package maliput`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
