### PR TITLE
Creates a maliput query application.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -101,9 +150,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.5.1",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -116,6 +200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +214,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "criterion"
@@ -135,7 +231,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -259,6 +355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +383,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.1",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -332,6 +451,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 name = "maliput"
 version = "0.3.0"
 dependencies = [
+ "clap 4.3.24",
  "criterion",
  "cxx",
  "maliput-sdk",
@@ -532,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +704,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"
@@ -683,3 +815,142 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,9 @@ license = "BSD-3-Clause"
 repository = "https://github.com/maliput/maliput-rs"
 
 [workspace.dependencies]
+cxx = { version = "1.0.78"}
+cxx-build = { version = "1.0.78"}
+clap = { version = "~4.3" }
+
 maliput-sdk = { version = "0.3", path = "maliput-sdk" }
 maliput-sys = { version = "0.3", path = "maliput-sys" }

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -15,8 +15,8 @@ repository.workspace = true
 build = "build.rs"
 
 [dependencies]
-cxx = "1.0.78"
+cxx = { workspace = true }
 maliput-sdk = { workspace = true }
 
 [build-dependencies]
-cxx-build = "1.0.78"
+cxx-build = { workspace = true }

--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -39,6 +39,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=src/api/rules/aliases.h");
     println!("cargo:rerun-if-changed=src/api/rules/rules.h");
     println!("cargo:rerun-if-changed=src/api/rules/mod.rs");
+    println!("cargo:rerun-if-changed=src/common/common.h");
+    println!("cargo:rerun-if-changed=src/common/mod.rs");
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/math/math.h");
     println!("cargo:rerun-if-changed=src/math/mod.rs");
@@ -69,6 +71,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "src/api/rules/mod.rs",
         "src/api/mod.rs",
         "src/plugin/mod.rs",
+        "src/common/mod.rs",
     ])
     .flag_if_supported("-std=c++17")
     .include("src")

--- a/maliput-sys/src/common/common.h
+++ b/maliput-sys/src/common/common.h
@@ -27,11 +27,19 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#![allow(rustdoc::bare_urls)]
-#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-pub mod api;
-pub mod common;
-pub mod math;
-pub mod plugin;
-pub mod utility;
+#pragma once
+
+#include <maliput/common/logger.h>
+
+#include <rust/cxx.h>
+
+namespace maliput {
+namespace common {
+
+rust::String LOG_set_log_level(const rust::str level) {
+  return maliput::common::set_log_level(std::string(level));
+}
+
+} // namespace common
+}  // namespace maliput

--- a/maliput-sys/src/common/mod.rs
+++ b/maliput-sys/src/common/mod.rs
@@ -27,11 +27,13 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#![allow(rustdoc::bare_urls)]
-#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-pub mod api;
-pub mod common;
-pub mod math;
-pub mod plugin;
-pub mod utility;
+#[cxx::bridge(namespace = "maliput::common")]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("common/common.h");
+
+        #[namespace = "maliput::common"]
+        fn LOG_set_log_level(level: &str) -> String;
+    }
+}

--- a/maliput-sys/tests/common_tests.rs
+++ b/maliput-sys/tests/common_tests.rs
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 //
-// Copyright (c) 2024, Woven by Toyota.
+// Copyright (c) 2025, Woven by Toyota.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -27,11 +27,27 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#![allow(rustdoc::bare_urls)]
-#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-pub mod api;
-pub mod common;
-pub mod math;
-pub mod plugin;
-pub mod utility;
+#[cfg(test)]
+mod common_test {
+    use maliput_sys::common::ffi::LOG_set_log_level;
+    #[test]
+    fn test_log_level() {
+        LOG_set_log_level("off");
+        let last_level = LOG_set_log_level("trace");
+        assert_eq!(last_level, "off");
+        let last_level = LOG_set_log_level("debug");
+        assert_eq!(last_level, "trace");
+        let last_level = LOG_set_log_level("info");
+        assert_eq!(last_level, "debug");
+        let last_level = LOG_set_log_level("warn");
+        assert_eq!(last_level, "info");
+        let last_level = LOG_set_log_level("error");
+        assert_eq!(last_level, "warn");
+        let last_level = LOG_set_log_level("critical");
+        assert_eq!(last_level, "error");
+        let last_level = LOG_set_log_level("unchanged");
+        assert_eq!(last_level, "critical");
+        // TODO(francocipollone): Test an invalid log level. It throws under the hood in c++.
+    }
+}

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -13,12 +13,17 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cxx = "1.0.78"
+clap = { workspace = true, features = ["derive"] }
+cxx = { workspace = true }
 maliput-sdk = { workspace = true }
 maliput-sys = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
+
+[[bin]]
+name = "maliput_query"
+path = "bin/maliput_query.rs"
 
 [[bench]]
 name = "to_road_position"

--- a/maliput/bin/maliput_query.rs
+++ b/maliput/bin/maliput_query.rs
@@ -1,0 +1,334 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! A command line tool to query a road network built from an OpenDRIVE file.
+//!
+//! e.g: cargo run --bin maliput_query -- maliput/data/xodr/ArcLane.xodr
+
+use clap::Parser;
+
+use maliput::api::RoadNetwork;
+use std::collections::HashMap;
+
+// Define the MaliputQuery enum to represent different types of queries that can be made to the road network.
+enum MaliputQuery {
+    GetNumberOfLanes,
+    GetTotalLengthOfTheRoadGeometry,
+    GetLaneLength(String),
+    ToRoadPosition(f64, f64, f64),             // x, y, z
+    ToLanePosition(String, f64, f64, f64),     // lane_id, x, y, z
+    ToSegmentPosition(String, f64, f64, f64),  // lane_id, x, y, z
+    ToInertialPosition(String, f64, f64, f64), // lane_id, s, r, h
+    GetOrientaiton(String, f64, f64, f64),     // lane_id, s, r, h
+    Invalid,
+}
+
+impl From<Vec<&str>> for MaliputQuery {
+    fn from(args: Vec<&str>) -> Self {
+        match args.as_slice() {
+            ["GetNumberOfLanes"] => MaliputQuery::GetNumberOfLanes,
+            ["GetTotalLengthOfTheRoadGeometry"] => MaliputQuery::GetTotalLengthOfTheRoadGeometry,
+            ["GetLaneLength", lane_id] => MaliputQuery::GetLaneLength(lane_id.to_string()),
+            ["ToRoadPosition", x, y, z] => {
+                MaliputQuery::ToRoadPosition(x.parse().unwrap(), y.parse().unwrap(), z.parse().unwrap())
+            }
+            ["ToLanePosition", lane_id, x, y, z] => MaliputQuery::ToLanePosition(
+                lane_id.to_string(),
+                x.parse().unwrap(),
+                y.parse().unwrap(),
+                z.parse().unwrap(),
+            ),
+            ["ToSegmentPosition", lane_id, x, y, z] => MaliputQuery::ToSegmentPosition(
+                lane_id.to_string(),
+                x.parse().unwrap(),
+                y.parse().unwrap(),
+                z.parse().unwrap(),
+            ),
+            ["ToInertialPosition", lane_id, s, r, h] => MaliputQuery::ToInertialPosition(
+                lane_id.to_string(),
+                s.parse().unwrap(),
+                r.parse().unwrap(),
+                h.parse().unwrap(),
+            ),
+            ["GetOrientation", lane_id, s, r, h] => MaliputQuery::GetOrientaiton(
+                lane_id.to_string(),
+                s.parse().unwrap(),
+                r.parse().unwrap(),
+                h.parse().unwrap(),
+            ),
+            _ => MaliputQuery::Invalid,
+        }
+    }
+}
+
+impl MaliputQuery {
+    fn print_available_queries() {
+        println!("Available commands:");
+        println!("1. GetNumberOfLanes");
+        println!("2. GetTotalLengthOfTheRoadGeometry");
+        println!("3. GetLaneLength <lane_id>");
+        println!("4. ToRoadPosition <x> <y> <z>");
+        println!("5. ToLanePosition <lane_id> <x> <y> <z>");
+        println!("6. ToSegmentPosition <lane_id> <x> <y> <z>");
+        println!("7. ToInertialPosition <lane_id> <s> <r> <h>");
+        println!("8. GetOrientation <lane_id> <s> <r> <h>");
+    }
+}
+
+struct RoadNetworkQuery<'a> {
+    rn: &'a RoadNetwork,
+}
+
+impl<'a> RoadNetworkQuery<'a> {
+    fn new(rn: &'a RoadNetwork) -> Self {
+        RoadNetworkQuery { rn }
+    }
+
+    fn execute_query(&self, query: MaliputQuery) {
+        let rg = self.rn.road_geometry();
+        let start_time = std::time::Instant::now();
+        match query {
+            MaliputQuery::GetNumberOfLanes => {
+                let len = rg.get_lanes().len();
+                print_elapsed_time(start_time);
+                println!("Number of lanes: {}", len);
+            }
+            MaliputQuery::GetTotalLengthOfTheRoadGeometry => {
+                let lanes_num = rg.get_lanes().len();
+                let total_length = rg.get_lanes().iter().map(|lane| lane.length()).sum::<f64>();
+                println!("Total length of the road geometry: {} meters along {} lanes. The average lane length is {} meters.",
+                total_length,
+                lanes_num,
+                total_length / lanes_num as f64);
+                print_elapsed_time(start_time);
+            }
+            MaliputQuery::GetLaneLength(lane_id) => {
+                if let Some(lane) = rg.get_lane(&lane_id) {
+                    let lane_length = lane.length();
+                    print_elapsed_time(start_time);
+                    println!("Length of lane {}: {} meters", lane_id, lane_length);
+                } else {
+                    println!("Lane with ID {} not found.", lane_id);
+                }
+            }
+            MaliputQuery::ToRoadPosition(x, y, z) => {
+                let road_position_result = rg.to_road_position(&maliput::api::InertialPosition::new(x, y, z));
+                print_elapsed_time(start_time);
+                println!("Road Position Result:");
+                println!("\t* Road Position:");
+                println!("\t\t* lane_id: {}", road_position_result.road_position.lane().id());
+                println!("\t\t* lane_position: {}", road_position_result.road_position.pos());
+                println!("\t* Nearest Position:");
+                println!("\t\t* inertial_position: {}", road_position_result.nearest_position);
+                println!("\t* Distance:");
+                println!("\t\t* distance: {}", road_position_result.distance);
+            }
+            MaliputQuery::ToLanePosition(lane_id, x, y, z) => {
+                if let Some(lane) = rg.get_lane(&lane_id) {
+                    let lane_position_result = lane.to_lane_position(&maliput::api::InertialPosition::new(x, y, z));
+                    print_elapsed_time(start_time);
+                    println!("Lane Position Result for lane {}:", lane_id);
+                    println!("\t* Lane Position:");
+                    println!("\t\t* lane_position: {}", lane_position_result.lane_position);
+                    println!("\t* Nearest Position:");
+                    println!("\t\t* inertial_position: {}", lane_position_result.nearest_position);
+                    println!("\t* Distance:");
+                    println!("\t\t* distance: {}", lane_position_result.distance);
+                } else {
+                    println!("Lane with ID {} not found.", lane_id);
+                }
+            }
+            MaliputQuery::ToSegmentPosition(lane_id, x, y, z) => {
+                if let Some(lane) = rg.get_lane(&lane_id) {
+                    let lane_position_result = lane.to_segment_position(&maliput::api::InertialPosition::new(x, y, z));
+                    print_elapsed_time(start_time);
+                    println!("Segment Position Result for lane {}:", lane_id);
+                    println!("\t* Lane Position:");
+                    println!("\t\t* lane_position: {}", lane_position_result.lane_position);
+                    println!("\t* Nearest Position:");
+                    println!("\t\t* inertial_position: {}", lane_position_result.nearest_position);
+                    println!("\t* Distance:");
+                    println!("\t\t* distance: {}", lane_position_result.distance);
+                } else {
+                    println!("Lane with ID {} not found.", lane_id);
+                }
+            }
+            MaliputQuery::ToInertialPosition(lane_id, s, r, h) => {
+                if let Some(lane) = rg.get_lane(&lane_id) {
+                    let inertial_position = lane.to_inertial_position(&maliput::api::LanePosition::new(s, r, h));
+                    print_elapsed_time(start_time);
+                    println!("Inertial Position Result for lane {}:", lane_id);
+                    println!("\t* inertial_position: {}", inertial_position);
+                } else {
+                    println!("Lane with ID {} not found.", lane_id);
+                }
+            }
+            MaliputQuery::GetOrientaiton(lane_id, s, r, h) => {
+                if let Some(lane) = rg.get_lane(&lane_id) {
+                    let orientation = lane.get_orientation(&maliput::api::LanePosition::new(s, r, h));
+                    print_elapsed_time(start_time);
+                    println!("Orientation Result for lane {}:", lane_id);
+                    println!("\t* orientation:");
+                    println!(
+                        "\t\t* roll: {}, pitch: {}, yaw: {}",
+                        orientation.roll(),
+                        orientation.pitch(),
+                        orientation.yaw()
+                    );
+                } else {
+                    println!("Lane with ID {} not found.", lane_id);
+                }
+            }
+            MaliputQuery::Invalid => {
+                println!("Invalid query command. Please try again.");
+                println!();
+                MaliputQuery::print_available_queries();
+            }
+        }
+        /// Print the elapsed time for the query execution.
+        fn print_elapsed_time(start_time: std::time::Instant) {
+            let elapsed = start_time.elapsed();
+            println!("Query executed in {:.2?}.", elapsed);
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    road_network_xodr_file_path: String,
+
+    /// Tolerance indicates the precision of the geometry being built in order
+    /// to make G1 continuity guarantees. A value of 0.5 is high. Ideally,
+    /// tolerances of 0.05 or 0.005 is ideal.
+    #[arg(short, long, default_value_t = 0.05)]
+    linear_tolerance: f64,
+
+    #[arg(short, long)]
+    max_linear_tolerance: Option<f64>,
+
+    #[arg(short, long, default_value_t = 0.01)]
+    angular_tolerance: f64,
+
+    #[arg(long, default_value_t = false)]
+    allow_non_drivable_lanes: bool,
+
+    #[arg(long, default_value_t = false)]
+    parallel_builder_policy: bool,
+
+    #[arg(long, default_value_t = maliput::common::LogLevel::Info)]
+    set_log_level: maliput::common::LogLevel,
+}
+
+// Parses the OpenDRIVE file path from the command line arguments.
+//  - if this is a relative path, it will be resolved against the current working directory.
+//  - if this is an absolute path, it will be used as is.
+use std::path::PathBuf;
+fn parse_xodr_file_path(path: &str) -> PathBuf {
+    let mut path_buf = PathBuf::from(path);
+    if !path_buf.is_absolute() {
+        // If the path is relative, resolve it against the current working directory.
+        if let Ok(current_dir) = std::env::current_dir() {
+            path_buf = current_dir.join(path_buf);
+        }
+    }
+    path_buf
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // Configuration for the road network.
+    let xodr_path = parse_xodr_file_path(args.road_network_xodr_file_path.as_str());
+    let linear_tolerance: String = args.linear_tolerance.to_string();
+    let max_linear_tolerance = args.max_linear_tolerance;
+    let angular_tolerance = args.angular_tolerance.to_string();
+    let omit_non_drivable_lanes = if args.allow_non_drivable_lanes { "false" } else { "true" };
+    let parallel_builder_policy = args.parallel_builder_policy;
+
+    let mut road_network_properties = HashMap::from([
+        ("road_geometry_id", "maliput_query_rg"),
+        ("opendrive_file", xodr_path.to_str().unwrap()),
+        ("linear_tolerance", linear_tolerance.as_str()),
+        ("omit_nondrivable_lanes", omit_non_drivable_lanes),
+        ("angular_tolerance", angular_tolerance.as_str()),
+        (
+            "parallel_builder_policy",
+            if parallel_builder_policy {
+                "parallel"
+            } else {
+                "sequential"
+            },
+        ),
+    ]);
+    let max_linear_tolerance_str;
+    if let Some(max_tolerance) = max_linear_tolerance {
+        max_linear_tolerance_str = max_tolerance.to_string();
+        road_network_properties.insert("max_linear_tolerance", max_linear_tolerance_str.as_str());
+    }
+
+    // Print the parsed arguments
+    println!(
+        "maliput_query application started with the following arguments: {:?}",
+        args
+    );
+    println!();
+    // Print the road network properties for debugging purposes.
+    println!("Road network properties: {:?}", road_network_properties);
+
+    maliput::common::set_log_level(args.set_log_level);
+    let now = std::time::Instant::now();
+    let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties);
+    let elapsed = now.elapsed();
+    println!("Road network loaded in {:.2?}.", elapsed);
+
+    // Print available commands
+    println!();
+    MaliputQuery::print_available_queries();
+    println!("To exit the application, type 'exit'.");
+
+    loop {
+        println!();
+        let mut input = String::new();
+        println!("Enter a query command (or 'exit' to quit):");
+        std::io::stdin().read_line(&mut input)?;
+        let input = input.trim();
+
+        if input == "exit" {
+            break;
+        }
+
+        let query: MaliputQuery = input.split_whitespace().collect::<Vec<&str>>().into();
+        let query_handler = RoadNetworkQuery::new(&road_network);
+        query_handler.execute_query(query);
+    }
+
+    Ok(())
+}

--- a/maliput/src/common/mod.rs
+++ b/maliput/src/common/mod.rs
@@ -1,0 +1,130 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/// Log levels for the under the hood maliput library's logging system.
+///
+/// See https://github.com/maliput/maliput/blob/main/include/maliput/common/logger.h
+/// for more details on the logging system and available log levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Off,
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Critical,
+    Unchanged,
+}
+
+impl From<LogLevel> for &'static str {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Off => "off",
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+            LogLevel::Critical => "critical",
+            LogLevel::Unchanged => "unchanged",
+        }
+    }
+}
+impl From<String> for LogLevel {
+    fn from(level: String) -> Self {
+        match level.as_str() {
+            "off" => LogLevel::Off,
+            "trace" => LogLevel::Trace,
+            "debug" => LogLevel::Debug,
+            "info" => LogLevel::Info,
+            "warn" => LogLevel::Warn,
+            "error" => LogLevel::Error,
+            "critical" => LogLevel::Critical,
+            "unchanged" => LogLevel::Unchanged,
+            _ => panic!("Invalid log level: {}", level),
+        }
+    }
+}
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Off => write!(f, "off"),
+            LogLevel::Trace => write!(f, "trace"),
+            LogLevel::Debug => write!(f, "debug"),
+            LogLevel::Info => write!(f, "info"),
+            LogLevel::Warn => write!(f, "warn"),
+            LogLevel::Error => write!(f, "error"),
+            LogLevel::Critical => write!(f, "critical"),
+            LogLevel::Unchanged => write!(f, "unchanged"),
+        }
+    }
+}
+
+/// Set the log level for the maliput library's logging system.
+///
+/// # Arguments
+///
+/// * `level` - The desired log level to set. This should be one of the variants of `LogLevel`.
+///
+/// # Returns
+///
+/// A string indicating the previous log level before the change.
+///
+pub fn set_log_level(level: LogLevel) -> LogLevel {
+    maliput_sys::common::ffi::LOG_set_log_level(level.into()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::set_log_level;
+    use super::LogLevel;
+    #[test]
+    fn test_log_level() {
+        set_log_level(LogLevel::Off);
+        let last_level = set_log_level(LogLevel::Trace);
+        assert_eq!(last_level, LogLevel::Off);
+        let last_level = set_log_level(LogLevel::Debug);
+        assert_eq!(last_level, LogLevel::Trace);
+        let last_level = set_log_level(LogLevel::Info);
+        assert_eq!(last_level, LogLevel::Debug);
+        let last_level = set_log_level(LogLevel::Warn);
+        assert_eq!(last_level, LogLevel::Info);
+        let last_level = set_log_level(LogLevel::Error);
+        assert_eq!(last_level, LogLevel::Warn);
+        let last_level = set_log_level(LogLevel::Critical);
+        assert_eq!(last_level, LogLevel::Error);
+        let last_level = set_log_level(LogLevel::Unchanged);
+        assert_eq!(last_level, LogLevel::Critical);
+        let last_level = set_log_level(LogLevel::Off);
+        assert_eq!(last_level, LogLevel::Critical);
+        // TODO(francocipollone): Test an invalid log level. It throws under the hood in c++.
+    }
+}

--- a/maliput/src/lib.rs
+++ b/maliput/src/lib.rs
@@ -33,6 +33,7 @@
 #[allow(clippy::needless_lifetimes)]
 // Remove after rust 1.87 is used. https://github.com/rust-lang/rust-clippy/issues/14441
 pub mod api;
+pub mod common;
 pub mod math;
 pub mod utility;
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - Creates maliput_query binary crate inspired on [maliput_query from maliput_integration](https://github.com/maliput/maliput_integration/blob/main/src/applications/maliput_query.cc) with some improvements.
 - Binds the `maliput::common::set_log_level` so logging level (from cpp) can be selected.

## Test it
Run with the help
```
cargo run --bin maliput_query -- --help
```
```
Usage: maliput_query [OPTIONS] <ROAD_NETWORK_XODR_FILE_PATH>

Arguments:
  <ROAD_NETWORK_XODR_FILE_PATH>  

Options:
  -l, --linear-tolerance <LINEAR_TOLERANCE>
          Tolerance indicates the precision of the geometry being built in order to make G1 continuity guarantees. A value of 0.5 is high. Ideally, tolerances of 0.05 or 0.005 is ideal [default: 0.05]
  -m, --max-linear-tolerance <MAX_LINEAR_TOLERANCE>
          
  -a, --angular-tolerance <ANGULAR_TOLERANCE>
          [default: 0.01]
      --allow-non-drivable-lanes
          
      --parallel-builder-policy
          
      --set-log-level <SET_LOG_LEVEL>
          [default: info]
  -h, --help
          Print help
  -V, --version
          Print version
```
For example run:
```
cargo run --bin maliput_query -- maliput/data/xodr/ArcLane.xodr --parallel-builder-policy --set-log-level=trace
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
