### PR TITLE
Solves rpath for maliput_query app.

### DIFF
--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -12,6 +12,8 @@ keywords.workspace = true
 license.workspace = true
 repository.workspace = true
 
+build = "build.rs"
+
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 cxx = { workspace = true }

--- a/maliput/bin/maliput_query.rs
+++ b/maliput/bin/maliput_query.rs
@@ -241,7 +241,7 @@ struct Args {
     allow_non_drivable_lanes: bool,
 
     #[arg(long, default_value_t = false)]
-    parallel_builder_policy: bool,
+    disable_parallel_builder_policy: bool,
 
     #[arg(long, default_value_t = maliput::common::LogLevel::Info)]
     set_log_level: maliput::common::LogLevel,
@@ -271,7 +271,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let max_linear_tolerance = args.max_linear_tolerance;
     let angular_tolerance = args.angular_tolerance.to_string();
     let omit_non_drivable_lanes = if args.allow_non_drivable_lanes { "false" } else { "true" };
-    let parallel_builder_policy = args.parallel_builder_policy;
+    let parallel_builder_policy = !args.disable_parallel_builder_policy;
 
     let mut road_network_properties = HashMap::from([
         ("road_geometry_id", "maliput_query_rg"),

--- a/maliput/build.rs
+++ b/maliput/build.rs
@@ -1,0 +1,50 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // This is a workaround to correctly have the .so files linked to the final binary.
+    // Cargo doesn’t propagate the crate’s link arguments to higher-level crates.
+    // We set two arguments: rpath and link-search. The rpath is intended for the final binary to link to the library, and link-search allows Cargo to locate the library.
+    //
+    // See: https://github.com/rust-lang/cargo/issues/5077
+    let maliput_bin_path =
+        PathBuf::from(env::var("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH").expect("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH not set"));
+
+    println!("cargo:rustc-link-search=native={}", maliput_bin_path.display());
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", maliput_bin_path.display());
+
+    Ok(())
+}


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
maliput_query crate:

This is a workaround to correctly have the .so files linked to the final binary
Cargo doesn’t propagate the crate’s link arguments to higher-level crates.

See: https://github.com/rust-lang/cargo/issues/5077


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
