### PR TITLE
Prepare for maliput-sdk 0.3.1 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "maliput-sys"

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.3.0",
+    version = "0.3.1",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -21,7 +21,7 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 | BCR Module | Current version |
 |------------|---------|
 | [maliput](https://registry.bazel.build/modules/maliput)    | 1.5.0 |
-| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.6.0 |
+| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.6.1 |
 
 ## Usage
 


### PR DESCRIPTION
# :balloon: Release

## Summary
* Prepare for maliput-sdk 0.3.1 release.

## After merge
- [ ] `cargo publish --dry-run --verbose --package maliput-sdk`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
