### PR TITLE
Fix yaml-cpp

### DIFF
--- a/maliput-sdk/.bazelrc
+++ b/maliput-sdk/.bazelrc
@@ -25,6 +25,7 @@ build --verbose_failures
 
 build --cxxopt="-std=c++17"
 build --cxxopt="-Werror"
+build --cxxopt=-include --cxxopt=cstdint
 
 # Silence compiler warnings for external dependencies.
 #  - https://github.com/bazelbuild/bazel/commit/08936aecb96f2937c61bdedfebcf1c5a41a0786d

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -82,6 +82,7 @@ fn get_bazel_library_version(library_name: &str) -> String {
 
 fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=.bazelrc");
     println!("cargo:rerun-if-changed=BUILD.bazel");
     println!("cargo:rerun-if-changed=MODULE.bazel");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
Fixes compillation of `yaml-cpp` on hosts with newer versions of gcc.

The error this fixes:

```
external/yaml-cpp~0.8.0/src/emitterutils.cpp:221:11: error: 'uint16_t' was not declared in this scope
    221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
        |           ^~~~~~~~
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:13:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
     12 | #include "yaml-cpp/null.h"
    +++ |+#include <cstdint>
     13 | #include "yaml-cpp/ostream_wrapper.h"
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:221:21: error: 'uint16_t' was not declared in this scope
    221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
        |                     ^~~~~~~~
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:221:21: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:221:29: error: template argument 1 is invalid
    221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
        |                             ^
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:221:29: error: template argument 2 is invalid
  external/yaml-cpp~0.8.0/src/emitterutils.cpp: In function 'int YAML::Utils::{anonymous}::EncodeUTF16SurrogatePair(int)':
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:222:9: error: 'uint32_t' does not name a type
    222 |   const uint32_t leadOffset = 0xD800 - (0x10000 >> 10);
        |         ^~~~~~~~
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:222:9: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:225:5: error: 'leadOffset' was not declared in this scope
    225 |     leadOffset | (codePoint >> 10),
        |     ^~~~~~~~~~
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:227:3: error: cannot convert '<brace-enclosed initializer list>' to 'int' in return
    227 |   };
        |   ^
  external/yaml-cpp~0.8.0/src/emitterutils.cpp: In function 'void YAML::Utils::{anonymous}::WriteDoubleQuoteEscapeSequence(YAML::ostream_wrapper&, int, YAML::StringEscaping::value)':
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:246:55: error: request for member 'first' in 'surrogatePair', which is of non-class type 'int'
    246 |     WriteDoubleQuoteEscapeSequence(out, surrogatePair.first, stringEscapingStyle);
        |                                                       ^~~~~
  external/yaml-cpp~0.8.0/src/emitterutils.cpp:247:55: error: request for member 'second' in 'surrogatePair', which is of non-class type 'int'
    247 |     WriteDoubleQuoteEscapeSequence(out, surrogatePair.second, stringEscapingStyle);
        |                                                       ^~~~~~
  Target //:maliput_sdk failed to build
  ```

