### PR TITLE
maliput-sdk patch release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "maliput-sys"

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -10,4 +10,4 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "maliput", version = "1.5.0")
-bazel_dep(name = "maliput_malidrive", version = "0.7.0")
+bazel_dep(name = "maliput_malidrive", version = "0.7.1")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -21,7 +21,7 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 | BCR Module | Current version |
 |------------|---------|
 | [maliput](https://registry.bazel.build/modules/maliput)    | 1.5.0 |
-| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.7.0 |
+| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.7.1 |
 
 ## Usage
 


### PR DESCRIPTION
# :balloon: Release

## Summary
 - Points to maliput_malidrive 0.7.1 BCR release 
 - Prepares for release

## After merge
- [ ] `cargo publish --dry-run --verbose --package maliput-sdk`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
