### PR TITLE
Update to_inertial_position docs.

### DIFF
--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -647,7 +647,11 @@ impl<'a> Lane<'a> {
     /// coordinates. It's on the user side to verify, if needed, that the lane position is within lane boundaries.
     /// Bare in mind that the inertial position will be a point in the `s-r` plane, but *not* necessarily on the road surface.
     ///
-    /// The s component of lane_position must be in domain [0, Lane::length()].
+    /// @param lane_position A maliput `LanePosition`.
+    ///
+    /// @pre The s component of @p lane_position must be in domain [0, Lane::length()].
+    ///
+    /// @returns an `InertialPosition` corresponding to the input `LanePosition`.
     pub fn to_inertial_position(&self, lane_position: &LanePosition) -> InertialPosition {
         InertialPosition {
             ip: maliput_sys::api::ffi::Lane_ToInertialPosition(self.lane, lane_position.lp.as_ref().expect("")),

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -641,6 +641,13 @@ impl<'a> Lane<'a> {
         }
     }
     /// Get the inertial position of the `Lane` at the given `LanePosition`.
+    ///
+    /// Note there is no constraint for the `r` coordinate, as it can be outside the lane boundaries.
+    /// In that scenario, the resultant inertial position represents a point in the `s-r` plane at the given `s` and `h`
+    /// coordinates. It's on the user side to verify, if needed, that the lane position is within lane boundaries.
+    /// Bare in mind that the inertial position will be a point in the `s-r` plane, but *not* necessarily on the road surface.
+    ///
+    /// The s component of lane_position must be in domain [0, Lane::length()].
     pub fn to_inertial_position(&self, lane_position: &LanePosition) -> InertialPosition {
         InertialPosition {
             ip: maliput_sys::api::ffi::Lane_ToInertialPosition(self.lane, lane_position.lp.as_ref().expect("")),

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -640,18 +640,23 @@ impl<'a> Lane<'a> {
             r: maliput_sys::api::ffi::Lane_GetOrientation(self.lane, lane_position.lp.as_ref().expect("")),
         }
     }
-    /// Get the inertial position of the `Lane` at the given `LanePosition`.
+    /// ## Brief
+    /// Get the [InertialPosition] of the [Lane] at the given [LanePosition].
     ///
+    /// ## Notes
     /// Note there is no constraint for the `r` coordinate, as it can be outside the lane boundaries.
     /// In that scenario, the resultant inertial position represents a point in the `s-r` plane at the given `s` and `h`
     /// coordinates. It's on the user side to verify, if needed, that the lane position is within lane boundaries.
     /// Bare in mind that the inertial position will be a point in the `s-r` plane, but *not* necessarily on the road surface.
     ///
-    /// @param lane_position A maliput `LanePosition`.
+    /// ## Arguments
+    /// * `lane_position` - A maliput [LanePosition].
     ///
-    /// @pre The s component of @p lane_position must be in domain [0, Lane::length()].
+    /// ## Precondition
+    /// The s component of `lane_position` must be in domain [0, Lane::length()].
     ///
-    /// @returns an `InertialPosition` corresponding to the input `LanePosition`.
+    /// ## Return
+    /// The [InertialPosition] corresponding to the input [LanePosition].
     pub fn to_inertial_position(&self, lane_position: &LanePosition) -> InertialPosition {
         InertialPosition {
             ip: maliput_sys::api::ffi::Lane_ToInertialPosition(self.lane, lane_position.lp.as_ref().expect("")),


### PR DESCRIPTION
# 🎉 Improve documentation

## Summary
Improves `to_inertial_position` documentation to better explain the domain of the input `LanePosition` and the image of the returned `InertialPosition`, so it matches the docs in maliput repository.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
