### PR TITLE
Sugar method to convert LaneEndSet to a lane_id-indexed map.

### DIFF
--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -1314,6 +1314,16 @@ impl<'a> LaneEndSet<'a> {
             false => LaneEnd::Finish(Lane { lane: lane_ref }),
         }
     }
+
+    /// Convert the LaneEndSet to a map of lane-id to LaneEnd.
+    pub fn to_lane_map(&self) -> std::collections::HashMap<String, LaneEnd> {
+        (0..self.size())
+            .map(|i| {
+                let end = self.get(i);
+                (end.lane().id(), end)
+            })
+            .collect()
+    }
 }
 
 /// A BranchPoint is a node in the network of a RoadGeometry at which

--- a/maliput/tests/branch_point_tests.rs
+++ b/maliput/tests/branch_point_tests.rs
@@ -46,6 +46,14 @@ fn branch_point_api() {
     assert_eq!(confluent_branches.size(), 1);
     let ongoing_branches = branch_point.get_ongoing_branches(&lane_end);
     assert_eq!(ongoing_branches.size(), 2);
+    let ongoing_branches_id_lane_end = ongoing_branches.to_lane_map();
+    assert_eq!(ongoing_branches_id_lane_end.len(), 2);
+    assert!(ongoing_branches_id_lane_end.contains_key("5_0_-1"));
+    assert!(ongoing_branches_id_lane_end.contains_key("9_0_-1"));
+    let lane_end_5 = ongoing_branches_id_lane_end.get("5_0_-1").unwrap();
+    let lane_end_9 = ongoing_branches_id_lane_end.get("9_0_-1").unwrap();
+    assert!(matches!(lane_end_5, maliput::api::LaneEnd::Start(_)));
+    assert!(matches!(lane_end_9, maliput::api::LaneEnd::Start(_)));
     let lane_end_set = branch_point.get_b_side();
     assert_eq!(lane_end_set.size(), 2);
 


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/maliput/maliput-rs/issues/170

## Summary
ditto


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
