### PR TITLE
API to obtain geo reference info.

### DIFF
--- a/maliput-sdk/.bazelrc
+++ b/maliput-sdk/.bazelrc
@@ -10,7 +10,7 @@ common --enable_bzlmod
 # common --registry=file://%workspace%/../bazel-central-registry
 
 # Central Registry
-build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/
+build --registry=https://bcr.bazel.build
 
 ########################################
 # Bazel Configuration

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -10,4 +10,4 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "maliput", version = "1.6.0")
-bazel_dep(name = "maliput_malidrive", version = "0.9.0")
+bazel_dep(name = "maliput_malidrive", version = "0.9.1")

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.5.1")
-bazel_dep(name = "maliput_malidrive", version = "0.8.0")
+bazel_dep(name = "maliput", version = "1.6.0")
+bazel_dep(name = "maliput_malidrive", version = "0.9.0")

--- a/maliput-sys/src/api/api.h
+++ b/maliput-sys/src/api/api.h
@@ -236,6 +236,10 @@ rust::String RoadGeometry_BackendCustomCommand(const RoadGeometry& road_geometry
   return road_geometry.BackendCustomCommand(std::string(command));
 }
 
+rust::String RoadGeometry_GeoReferenceInfo(const RoadGeometry& road_geometry) {
+  return road_geometry.GeoReferenceInfo();
+}
+
 std::unique_ptr<Rotation> Rotation_new() {
   return std::make_unique<Rotation>();
 }

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -91,6 +91,7 @@ pub mod ffi {
         fn RoadGeometry_GetJunction(rg: &RoadGeometry, junction_id: &String) -> *const Junction;
         fn RoadGeometry_GetBranchPoint(rg: &RoadGeometry, branch_point_id: &String) -> *const BranchPoint;
         fn RoadGeometry_BackendCustomCommand(rg: &RoadGeometry, command: &String) -> String;
+        fn RoadGeometry_GeoReferenceInfo(rg: &RoadGeometry) -> String;
         // LanePosition bindings definitions.
         type LanePosition;
         fn LanePosition_new(s: f64, r: f64, h: f64) -> UniquePtr<LanePosition>;

--- a/maliput/README.md
+++ b/maliput/README.md
@@ -31,7 +31,7 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
       ("opendrive_file", xodr_path.as_str()),
   ]);
 
-  let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties);
+  let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties)?;
   let road_geometry = road_network.road_geometry();
 
   // Excercise the RoadGeometry API.

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -194,6 +194,13 @@ impl<'a> RoadGeometry<'a> {
     pub fn backend_custom_command(&self, command: &String) -> String {
         maliput_sys::api::ffi::RoadGeometry_BackendCustomCommand(self.rg, command)
     }
+    /// Obtains the Geo Reference info of this RoadGeometry.
+    ///
+    /// ### Return
+    /// A string containing the Geo Reference projection, if any.
+    pub fn geo_reference_info(&self) -> String {
+        maliput_sys::api::ffi::RoadGeometry_GeoReferenceInfo(self.rg)
+    }
 }
 
 /// A RoadNetwork.

--- a/maliput/tests/common/mod.rs
+++ b/maliput/tests/common/mod.rs
@@ -70,6 +70,25 @@ pub fn create_arc_lane_road_network() -> RoadNetwork {
 }
 
 #[allow(dead_code)]
+pub fn create_town_01_road_network() -> RoadNetwork {
+    // Get location of odr resources
+    let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let xodr_path = format!("{}/data/xodr/Town01.xodr", package_location);
+
+    let road_network_properties = HashMap::from([
+        ("road_geometry_id", "my_rg_from_rust"),
+        ("opendrive_file", xodr_path.as_str()),
+        ("linear_tolerance", "0.01"),
+    ]);
+    let rn_res = RoadNetwork::new("maliput_malidrive", &road_network_properties);
+    assert!(
+        rn_res.is_ok(),
+        "Expected RoadNetwork to be created successfully with Town01.xodr"
+    );
+    rn_res.unwrap()
+}
+
+#[allow(dead_code)]
 pub fn create_t_shape_road_network_with_books() -> RoadNetwork {
     let rm = ResourceManager::new();
     let t_shape_xodr_path = rm

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -121,3 +121,17 @@ fn backend_custom_command() {
     let result = road_geometry.backend_custom_command(&command);
     assert_eq!(result, "0.000000,-0.000000,1.250000");
 }
+
+#[test]
+fn geo_reference_info() {
+    let road_network = common::create_arc_lane_road_network();
+    let road_geometry = road_network.road_geometry();
+    let expected_geo_ref = String::from("");
+    let actual_geo_ref = road_geometry.geo_reference_info();
+    assert_eq!(actual_geo_ref, expected_geo_ref);
+    let road_network = common::create_town_01_road_network();
+    let road_geometry = road_network.road_geometry();
+    let expected_geo_ref = String::from("+lat_0=4.9000000000000000e+1 +lon_0=8.0000000000000000e+0");
+    let actual_geo_ref = road_geometry.geo_reference_info();
+    assert_eq!(actual_geo_ref, expected_geo_ref);
+}

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -124,14 +124,18 @@ fn backend_custom_command() {
 
 #[test]
 fn geo_reference_info() {
-    let road_network = common::create_arc_lane_road_network();
-    let road_geometry = road_network.road_geometry();
-    let expected_geo_ref = String::from("");
-    let actual_geo_ref = road_geometry.geo_reference_info();
-    assert_eq!(actual_geo_ref, expected_geo_ref);
     let road_network = common::create_town_01_road_network();
     let road_geometry = road_network.road_geometry();
     let expected_geo_ref = String::from("+lat_0=4.9000000000000000e+1 +lon_0=8.0000000000000000e+0");
+    let actual_geo_ref = road_geometry.geo_reference_info();
+    assert_eq!(actual_geo_ref, expected_geo_ref);
+}
+
+#[test]
+fn geo_reference_info_empty() {
+    let road_network = common::create_arc_lane_road_network();
+    let road_geometry = road_network.road_geometry();
+    let expected_geo_ref = String::from("");
     let actual_geo_ref = road_geometry.geo_reference_info();
     assert_eq!(actual_geo_ref, expected_geo_ref);
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary
* Provides API to obtain the Geo Reference description from Rust.
* The description is provided in a String and it is up to the user to parse it.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
