### PR TITLE
Prepare for 0.6 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maliput"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap 4.3.24",
  "criterion",
@@ -461,11 +461,11 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "maliput-sys"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ cxx-build = { version = "1.0.78" }
 clap = { version = "~4.3" }
 thiserror = { version = "1.0" }
 
-maliput-sdk = { version = "0.5", path = "maliput-sdk" }
-maliput-sys = { version = "0.5", path = "maliput-sys" }
+maliput-sdk = { version = "0.6", path = "maliput-sdk" }
+maliput-sys = { version = "0.6", path = "maliput-sys" }

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.5.0",
+    version = "0.6.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -20,8 +20,8 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 
 | BCR Module | Current version |
 |------------|---------|
-| [maliput](https://registry.bazel.build/modules/maliput)    | 1.5.1 |
-| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.8.0 |
+| [maliput](https://registry.bazel.build/modules/maliput)    | 1.6.0 |
+| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.9.1 |
 
 ## Usage
 

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sys"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "FFI Rust bindings for maliput"

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["simulation"]
 description = "Rust API for maliput"


### PR DESCRIPTION
# :balloon: Release

## Summary
* Prepare for `maliput-sdk`, `maliput-sys` and `maliput` release 0.6.0

## After merge
* [ ] `cargo publish --dry-run --verbose --package maliput-sdk`
* [ ] `cargo publish --dry-run --verbose --package maliput-sys`
* [ ] `cargo publish --dry-run --verbose --package maliput`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
