### PR TITLE
Error handling: Override cxx's trycatch.

### DIFF
--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -41,6 +41,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=src/api/rules/mod.rs");
     println!("cargo:rerun-if-changed=src/common/common.h");
     println!("cargo:rerun-if-changed=src/common/mod.rs");
+    println!("cargo:rerun-if-changed=src/cxx_utils/error_handling.h");
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/math/math.h");
     println!("cargo:rerun-if-changed=src/math/mod.rs");

--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -52,6 +52,7 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("api/api.h");
+        include!("cxx_utils/error_handling.h");
 
         #[namespace = "maliput::math"]
         type Vector3 = crate::math::ffi::Vector3;

--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -104,6 +104,7 @@ pub mod ffi {
     unsafe extern "C++" {
         include!("api/rules/rules.h");
         include!("api/rules/aliases.h");
+        include!("cxx_utils/error_handling.h");
 
         // Forward declarations
         #[namespace = "maliput::api"]

--- a/maliput-sys/src/common/mod.rs
+++ b/maliput-sys/src/common/mod.rs
@@ -32,6 +32,7 @@
 pub mod ffi {
     unsafe extern "C++" {
         include!("common/common.h");
+        include!("cxx_utils/error_handling.h");
 
         #[namespace = "maliput::common"]
         fn LOG_set_log_level(level: &str) -> String;

--- a/maliput-sys/src/cxx_utils/error_handling.h
+++ b/maliput-sys/src/cxx_utils/error_handling.h
@@ -1,0 +1,59 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <maliput/common/assertion_error.h>
+
+#include <rust/cxx.h>
+
+namespace rust {
+namespace behavior {
+
+/// Customized error handling for Rust bindings.
+/// See https://cxx.rs/binding/result.html#returning-result-from-c-to-rust
+/// for more details.
+template <typename Try, typename Fail>
+static void trycatch(Try &&func, Fail &&fail) noexcept {
+  try {
+    func();
+  } catch (const maliput::common::assertion_error &e) {
+    fail("maliput::common::assertion_error: " + std::string(e.what()));
+  } catch (const std::exception &e) {
+    fail("std::exception: " + std::string(e.what()));
+  } catch (...) {
+    fail("Unknown error type: " +
+         std::string(typeid(std::current_exception()).name()));
+  }
+}
+
+}  // namespace behavior
+}  // namespace rust

--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -31,6 +31,7 @@
 #[cxx::bridge(namespace = "maliput::math")]
 pub mod ffi {
     unsafe extern "C++" {
+        include!("cxx_utils/error_handling.h");
         include!("math/math.h");
 
         #[namespace = "maliput::math"]

--- a/maliput-sys/src/plugin/mod.rs
+++ b/maliput-sys/src/plugin/mod.rs
@@ -31,6 +31,7 @@
 #[cxx::bridge(namespace = "maliput::plugin")]
 pub mod ffi {
     unsafe extern "C++" {
+        include!("cxx_utils/error_handling.h");
         include!("plugin/plugin.h");
 
         #[namespace = "maliput::api"]

--- a/maliput-sys/src/utility/mod.rs
+++ b/maliput-sys/src/utility/mod.rs
@@ -81,6 +81,7 @@ pub mod ffi {
         pub highlighted_segments: Vec<String>,
     }
     unsafe extern "C++" {
+        include!("cxx_utils/error_handling.h");
         include!("utility/utility.h");
 
         #[namespace = "maliput::api"]

--- a/maliput-sys/tests/plugin_tests.rs
+++ b/maliput-sys/tests/plugin_tests.rs
@@ -49,7 +49,7 @@ mod plugin_tests {
     fn create_invalid_road_network_test() {
         std::env::set_var("MALIPUT_PLUGIN_PATH", maliput_sdk::get_maliput_malidrive_plugin_path());
         let road_network_loader_id = String::from("maliput_malidrive");
-        let invalid_xodr_path = "/hopefully/this/path/does/not/exist.xodr".to_string();
+        let invalid_xodr_path = "opendrive_file:/hopefully/this/path/does/not/exist.xodr".to_string();
         let road_network_properties = vec![invalid_xodr_path];
         let rn_res = CreateRoadNetwork(&road_network_loader_id, &road_network_properties);
         assert!(

--- a/maliput/src/common/mod.rs
+++ b/maliput/src/common/mod.rs
@@ -40,7 +40,12 @@ pub enum MaliputError {
 
 impl From<cxx::Exception> for MaliputError {
     fn from(e: cxx::Exception) -> Self {
-        MaliputError::AssertionError(e.to_string())
+        let msg = e.to_string();
+        if msg.contains("maliput::common::assertion_error") {
+            MaliputError::AssertionError(msg)
+        } else {
+            MaliputError::Other(msg)
+        }
     }
 }
 


### PR DESCRIPTION
# 🎉 New feature

Related to #183 

## Summary
 - Customize error message based on the error type. The only error coming from maliput at the moment is `maliput::common::assertion_error`, but this will change in the near future.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.