### PR TITLE
Update default rust toolchain to 1.87.

### DIFF
--- a/.devcontainer/rust-zen/Dockerfile
+++ b/.devcontainer/rust-zen/Dockerfile
@@ -15,7 +15,7 @@ FROM mcr.microsoft.com/devcontainers/base:${BASE_IMAGE}
 ################################################################################
 
 ARG BAZEL_VERSION=6.4.0
-ARG RUST_VERSION=1.83.0
+ARG RUST_VERSION=1.87.0
 
 ################################################################################
 # User 'zen'

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -70,7 +70,7 @@ fn get_bazel_library_version(library_name: &str) -> String {
         .nth(line_index)
         .expect("Failed to retrieve the line from the process output.")
         .split('@')
-        .last()
+        .next_back()
         .expect("Failed to retrieve library version.")
         .trim(); // Remove trailing spaces.
     if library_version == "_" {

--- a/maliput-sys/README.md
+++ b/maliput-sys/README.md
@@ -30,7 +30,7 @@ For example:
 ## Examples
 
  - Load `maliput::api::RoadNetwork` and perform some basic queries.
-    ```
+    ```bash
     cargo run --example create_rn
     ```
 

--- a/maliput/README.md
+++ b/maliput/README.md
@@ -22,28 +22,31 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
   use maliput::api::RoadNetwork;
   use std::collections::HashMap;
 
-  // Get location of odr resources
-  let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-  let xodr_path = format!("{}/data/xodr/TShapeRoad.xodr", package_location);
+  fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get location of odr resources
+    let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let xodr_path = format!("{}/data/xodr/TShapeRoad.xodr", package_location);
 
-  let road_network_properties = HashMap::from([
-      ("road_geometry_id", "my_rg_from_rust"),
-      ("opendrive_file", xodr_path.as_str()),
-  ]);
+    let road_network_properties = HashMap::from([
+        ("road_geometry_id", "my_rg_from_rust"),
+        ("opendrive_file", xodr_path.as_str()),
+    ]);
 
-  let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties)?;
-  let road_geometry = road_network.road_geometry();
+    let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties)?;
+    let road_geometry = road_network.road_geometry();
 
-  // Excercise the RoadGeometry API.
-  println!("linear_tolerance: {}", road_geometry.linear_tolerance());
-  println!("angular_tolerance: {}", road_geometry.angular_tolerance());
-  println!("num_junctions: {}", road_geometry.num_junctions());
+    // Excercise the RoadGeometry API.
+    println!("linear_tolerance: {}", road_geometry.linear_tolerance());
+    println!("angular_tolerance: {}", road_geometry.angular_tolerance());
+    println!("num_junctions: {}", road_geometry.num_junctions());
 
-  let lanes = road_geometry.get_lanes();
-  println!("num_lanes: {}", lanes.len());
-  println!("lanes: ");
-  for lane in lanes {
-      println!("\tlane id: {}", lane.id());
+    let lanes = road_geometry.get_lanes();
+    println!("num_lanes: {}", lanes.len());
+    println!("lanes: ");
+    for lane in lanes {
+        println!("\tlane id: {}", lane.id());
+    }
+    Ok(())
   }
 ```
 
@@ -51,14 +54,14 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 ## Examples
 
  - Load `maliput::api::RoadNetwork` and perform some basic queries against the Road Geometry.
-    ```
-    cargo run --example road_geometry
+    ```bash
+    cargo run --example 01_road_geometry
     ```
 
 ## Benches
 
  - Evaluate the execution of `maliput::api::RoadGeometry::to_road_position` method.
-    ```
+    ```bash
     cargo bench to_road_position
     ```
 

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -136,7 +136,7 @@ impl<'a> RoadGeometry<'a> {
     /// let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     /// let xodr_path = format!("{}/data/xodr/TShapeRoad.xodr", package_location);
     /// let road_network_properties = HashMap::from([("road_geometry_id", "my_rg_from_rust"), ("opendrive_file", xodr_path.as_str())]);
-    /// let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties)?;
+    /// let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties).unwrap();
     /// let road_geometry = road_network.road_geometry();
     /// let lanes = road_geometry.get_lanes();
     /// for lane in lanes {
@@ -215,7 +215,7 @@ impl<'a> RoadGeometry<'a> {
 /// let package_location = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 /// let xodr_path = format!("{}/data/xodr/TShapeRoad.xodr", package_location);
 /// let road_network_properties = HashMap::from([("road_geometry_id", "my_rg_from_rust"), ("opendrive_file", xodr_path.as_str())]);
-/// let road_network = RoadNetwork::new("maliput_malidrive", &road_network_properties)?;
+/// let road_network = maliput::api::RoadNetwork::new("maliput_malidrive", &road_network_properties).unwrap();
 /// let road_geometry = road_network.road_geometry();
 /// println!("num_junctions: {}", road_geometry.num_junctions());
 /// ```

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -610,7 +610,7 @@ impl DiscreteValueRule {
     pub fn type_id(&self) -> String {
         maliput_sys::api::rules::ffi::DiscreteValueRule_type_id(&self.discrete_value_rule)
     }
-    /// Returns a [LaneSRoute] that represents the zone that the rule applies to.
+    /// Returns a [crate::api::LaneSRoute] that represents the zone that the rule applies to.
     pub fn zone(&self) -> crate::api::LaneSRoute {
         let lane_s_route = maliput_sys::api::rules::ffi::DiscreteValueRule_zone(&self.discrete_value_rule);
         crate::api::LaneSRoute { lane_s_route }
@@ -665,7 +665,7 @@ impl RangeValueRule {
     pub fn type_id(&self) -> String {
         maliput_sys::api::rules::ffi::RangeValueRule_type_id(&self.range_value_rule)
     }
-    /// Returns a [LaneSRoute] that represents the zone that the rule applies to.
+    /// Returns a [crate::api::LaneSRoute] that represents the zone that the rule applies to.
     pub fn zone(&self) -> crate::api::LaneSRoute {
         let lane_s_route = maliput_sys::api::rules::ffi::RangeValueRule_zone(&self.range_value_rule);
         crate::api::LaneSRoute { lane_s_route }

--- a/maliput/src/lib.rs
+++ b/maliput/src/lib.rs
@@ -43,8 +43,8 @@ pub mod utility;
 ///
 /// ### Backends
 ///  - maliput_malidrive: Resources from maliput_malidrive are brought by maliput-sdk package.
-///                       All the maliput_malidrive resources are stored in the same directory:
-///                       (See https://github.com/maliput/maliput_malidrive/tree/main/resources)
+///    All the maliput_malidrive resources are stored in the same directory:
+///    (See https://github.com/maliput/maliput_malidrive/tree/main/resources)
 /// ### Example
 ///
 /// How to get all the resources from the maliput_malidrive backend:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.87.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - Update default rust toolchain to 1.87.
 - Fix some docs errors
 - Fix some clippy suggestions

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
