### PR TITLE
Provide error mapping for maliput::api module.

### DIFF
--- a/maliput-sys/src/api/mod.rs
+++ b/maliput-sys/src/api/mod.rs
@@ -85,13 +85,13 @@ pub mod ffi {
         fn RoadGeometry_ToRoadPosition(
             rg: &RoadGeometry,
             inertial_position: &InertialPosition,
-        ) -> UniquePtr<RoadPositionResult>;
+        ) -> Result<UniquePtr<RoadPositionResult>>;
         fn RoadGeometry_GetLane(rg: &RoadGeometry, lane_id: &String) -> ConstLanePtr;
         fn RoadGeometry_GetLanes(rg: &RoadGeometry) -> UniquePtr<CxxVector<ConstLanePtr>>;
         fn RoadGeometry_GetSegment(rg: &RoadGeometry, segment_id: &String) -> *const Segment;
         fn RoadGeometry_GetJunction(rg: &RoadGeometry, junction_id: &String) -> *const Junction;
         fn RoadGeometry_GetBranchPoint(rg: &RoadGeometry, branch_point_id: &String) -> *const BranchPoint;
-        fn RoadGeometry_BackendCustomCommand(rg: &RoadGeometry, command: &String) -> String;
+        fn RoadGeometry_BackendCustomCommand(rg: &RoadGeometry, command: &String) -> Result<String>;
         fn RoadGeometry_GeoReferenceInfo(rg: &RoadGeometry) -> String;
         // LanePosition bindings definitions.
         type LanePosition;
@@ -141,8 +141,14 @@ pub mod ffi {
         fn Lane_elevation_bounds(lane: &Lane, s: f64, r: f64) -> UniquePtr<HBounds>;
         fn Lane_GetOrientation(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<Rotation>;
         fn Lane_ToInertialPosition(lane: &Lane, lane_position: &LanePosition) -> UniquePtr<InertialPosition>;
-        fn Lane_ToLanePosition(lane: &Lane, inertial_position: &InertialPosition) -> UniquePtr<LanePositionResult>;
-        fn Lane_ToSegmentPosition(lane: &Lane, inertial_position: &InertialPosition) -> UniquePtr<LanePositionResult>;
+        fn Lane_ToLanePosition(
+            lane: &Lane,
+            inertial_position: &InertialPosition,
+        ) -> Result<UniquePtr<LanePositionResult>>;
+        fn Lane_ToSegmentPosition(
+            lane: &Lane,
+            inertial_position: &InertialPosition,
+        ) -> Result<UniquePtr<LanePositionResult>>;
         fn Lane_GetBranchPoint(lane: &Lane, start: bool) -> *const BranchPoint;
         fn Lane_GetConfluentBranches(lane: &Lane, start: bool) -> *const LaneEndSet;
         fn Lane_GetOngoingBranches(lane: &Lane, start: bool) -> *const LaneEndSet;
@@ -166,7 +172,7 @@ pub mod ffi {
         type Junction;
         fn road_geometry(self: &Junction) -> *const RoadGeometry;
         fn num_segments(self: &Junction) -> i32;
-        fn segment(self: &Junction, index: i32) -> *const Segment;
+        fn segment(self: &Junction, index: i32) -> Result<*const Segment>;
         fn Junction_id(junction: &Junction) -> String;
 
         // RoadPosition bindings definitions
@@ -265,7 +271,7 @@ pub mod ffi {
         // LaneEndSet bindings definitions
         type LaneEndSet;
         fn size(self: &LaneEndSet) -> i32;
-        fn get(self: &LaneEndSet, index: i32) -> &LaneEnd;
+        fn get(self: &LaneEndSet, index: i32) -> Result<&LaneEnd>;
 
         // BranchPoint bindings definitions
         type BranchPoint;

--- a/maliput/bin/maliput_query.rs
+++ b/maliput/bin/maliput_query.rs
@@ -35,6 +35,7 @@
 use clap::Parser;
 
 use maliput::api::{LanePosition, RoadNetwork};
+use maliput::common::MaliputError;
 use std::collections::HashMap;
 
 // Define the MaliputQuery enum to represent different types of queries that can be made to the road network.
@@ -273,7 +274,7 @@ impl<'a> RoadNetworkQuery<'a> {
         RoadNetworkQuery { rn }
     }
 
-    fn execute_query(&self, query: MaliputQuery) {
+    fn execute_query(&self, query: MaliputQuery) -> Result<(), MaliputError> {
         let rg = self.rn.road_geometry();
         let start_time = std::time::Instant::now();
         match query {
@@ -346,7 +347,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 }
             }
             MaliputQuery::ToRoadPosition(x, y, z) => {
-                let road_position_result = rg.to_road_position(&maliput::api::InertialPosition::new(x, y, z));
+                let road_position_result = rg.to_road_position(&maliput::api::InertialPosition::new(x, y, z))?;
                 print_elapsed_time(start_time);
                 println!("-> Road Position Result:");
                 println!("\t* Road Position:");
@@ -359,7 +360,7 @@ impl<'a> RoadNetworkQuery<'a> {
             }
             MaliputQuery::ToLanePosition(lane_id, x, y, z) => {
                 if let Some(lane) = rg.get_lane(&lane_id) {
-                    let lane_position_result = lane.to_lane_position(&maliput::api::InertialPosition::new(x, y, z));
+                    let lane_position_result = lane.to_lane_position(&maliput::api::InertialPosition::new(x, y, z))?;
                     print_elapsed_time(start_time);
                     println!("-> Lane Position Result for lane {}:", lane_id);
                     println!("\t* Lane Position:");
@@ -374,7 +375,8 @@ impl<'a> RoadNetworkQuery<'a> {
             }
             MaliputQuery::ToSegmentPosition(lane_id, x, y, z) => {
                 if let Some(lane) = rg.get_lane(&lane_id) {
-                    let lane_position_result = lane.to_segment_position(&maliput::api::InertialPosition::new(x, y, z));
+                    let lane_position_result =
+                        lane.to_segment_position(&maliput::api::InertialPosition::new(x, y, z))?;
                     print_elapsed_time(start_time);
                     println!("-> Segment Position Result for lane {}:", lane_id);
                     println!("\t* Lane Position:");
@@ -417,7 +419,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for OpenScenarioRoadPositionToMaliputRoadPosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> OpenScenarioRoadPositionToMaliputRoadPosition Result:");
@@ -435,7 +437,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for OpenScenarioLanePositionToMaliputRoadPosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> OpenScenarioLanePositionToMaliputRoadPosition Result:");
@@ -453,7 +455,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for MaliputRoadPositionToOpenScenarioRoadPosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> MaliputRoadPositionToOpenScenarioRoadPosition Result:");
@@ -470,7 +472,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for MaliputRoadPositionToOpenScenarioLanePosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> MaliputRoadPositionToOpenScenarioLanePosition Result for lane:");
@@ -488,7 +490,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for OpenScenarioRelativeRoadPositionToMaliputRoadPosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> OpenScenarioRelativeRoadPositionToMaliputRoadPosition Result:");
@@ -506,7 +508,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query.to_backend_custom_command_format().expect(
                     "Invalid query command format for OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition",
                 );
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition Result:");
@@ -524,7 +526,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query.to_backend_custom_command_format().expect(
                     "Invalid query command format for OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition",
                 );
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition Result:");
@@ -542,7 +544,7 @@ impl<'a> RoadNetworkQuery<'a> {
                 let command = query
                     .to_backend_custom_command_format()
                     .expect("Invalid query command format for GetRoadOrientationAtOpenScenarioRoadPosition");
-                let res = rg.backend_custom_command(&command);
+                let res = rg.backend_custom_command(&command)?;
                 print_elapsed_time(start_time);
                 let res: Vec<&str> = res.split(',').collect();
                 println!("-> GetRoadOrientationAtOpenScenarioRoadPosition Result:");
@@ -566,6 +568,7 @@ impl<'a> RoadNetworkQuery<'a> {
             let elapsed = start_time.elapsed();
             println!("-> Query executed in {:.2?}.", elapsed);
         }
+        Ok(())
     }
 }
 
@@ -681,7 +684,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let query: MaliputQuery = input.split_whitespace().collect::<Vec<&str>>().into();
         let query_handler = RoadNetworkQuery::new(&road_network);
-        query_handler.execute_query(query);
+        query_handler.execute_query(query)?;
     }
 
     Ok(())

--- a/maliput/tests/branch_point_tests.rs
+++ b/maliput/tests/branch_point_tests.rs
@@ -41,7 +41,7 @@ fn branch_point_api() {
     // cpp tests.
     let lane_end_set = branch_point.get_a_side();
     assert_eq!(lane_end_set.size(), 1);
-    let lane_end = lane_end_set.get(0);
+    let lane_end = lane_end_set.get(0).unwrap();
     let confluent_branches = branch_point.get_confluent_branches(&lane_end);
     assert_eq!(confluent_branches.size(), 1);
     let ongoing_branches = branch_point.get_ongoing_branches(&lane_end);

--- a/maliput/tests/junction_tests.rs
+++ b/maliput/tests/junction_tests.rs
@@ -39,6 +39,6 @@ fn junction_api() {
     assert_eq!(junction.id(), junction_id);
     let num_segments = junction.num_segments();
     assert_eq!(num_segments, 1);
-    let segment = junction.segment(0);
+    let segment = junction.segment(0).unwrap();
     assert_eq!(segment.id(), String::from("0_0"));
 }

--- a/maliput/tests/lane_test.rs
+++ b/maliput/tests/lane_test.rs
@@ -37,7 +37,7 @@ fn lane_api() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
 
-    let road_position_result = road_geometry.to_road_position(&inertial_pos);
+    let road_position_result = road_geometry.to_road_position(&inertial_pos).unwrap();
     assert_eq!(road_position_result.road_position.lane().id(), expected_lane_id);
     let lane = road_position_result.road_position.lane();
     let index = lane.index();
@@ -61,9 +61,9 @@ fn lane_api() {
     assert!((ret_inertial_position.x() - inertial_pos.x()).abs() < tolerance);
     assert!((ret_inertial_position.y() - inertial_pos.y()).abs() < tolerance);
     assert!((ret_inertial_position.z() - inertial_pos.z()).abs() < tolerance);
-    let ret_lane_position = lane.to_lane_position(&ret_inertial_position);
+    let ret_lane_position = lane.to_lane_position(&ret_inertial_position).unwrap();
     assert_eq!(ret_lane_position.distance, road_position_result.distance);
-    let ret_segment_position = lane.to_segment_position(&inertial_pos);
+    let ret_segment_position = lane.to_segment_position(&inertial_pos).unwrap();
     assert_eq!(ret_segment_position.distance, road_position_result.distance);
     let left_lane = lane.to_left();
     let right_lane = lane.to_right();

--- a/maliput/tests/road_geometry_test.rs
+++ b/maliput/tests/road_geometry_test.rs
@@ -52,7 +52,7 @@ fn to_road_position() {
     let road_network = common::create_t_shape_road_network();
     let road_geometry = road_network.road_geometry();
 
-    let road_position_result = road_geometry.to_road_position(&expected_nearest_position);
+    let road_position_result = road_geometry.to_road_position(&expected_nearest_position).unwrap();
     assert_eq!(road_position_result.road_position.lane().id(), expected_lane_id);
     common::assert_lane_position_equality(
         &road_position_result.road_position.pos(),
@@ -97,28 +97,28 @@ fn backend_custom_command() {
     let road_geometry = road_network.road_geometry();
 
     let command = String::from("OpenScenarioLanePositionToMaliputRoadPosition,1,50,-1,0.");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1_0_-1,51.250000,0.000000,0.000000");
     let command = String::from("OpenScenarioRoadPositionToMaliputRoadPosition,1,50,0.");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1_0_-1,51.250000,1.000000,0.000000");
     let command = String::from("MaliputRoadPositionToOpenScenarioLanePosition,1_0_-1,51.250000,0.000000,0.000000");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1,50.000000,-1,0.000000");
     let command = String::from("MaliputRoadPositionToOpenScenarioRoadPosition,1_0_-1,51.250000,1.000000,0.000000");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1,50.000000,0.000000");
     let command = String::from("OpenScenarioRelativeRoadPositionToMaliputRoadPosition,1,0.,1.,50.,1.");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1_0_1,48.750000,1.000000,0.000000");
     let command = String::from("OpenScenarioRelativeLanePositionWithDsToMaliputRoadPosition,1,1,0.,-1,50.,-0.8");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1_0_-1,48.750000,-0.800000,0.000000");
     let command = String::from("OpenScenarioRelativeLanePositionWithDsLaneToMaliputRoadPosition,1,-1,0.,1,50.,0.8");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "1_0_1,50.000000,0.800000,0.000000");
     let command = String::from("GetRoadOrientationAtOpenScenarioRoadPosition,1,50.,0.");
-    let result = road_geometry.backend_custom_command(&command);
+    let result = road_geometry.backend_custom_command(&command).unwrap();
     assert_eq!(result, "0.000000,-0.000000,1.250000");
 }
 


### PR DESCRIPTION
# 🎉 New feature

Relates to #183 

## Summary
Return `Result<(), MaliputError>` in the necessary bindings from `maliput::api`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
