### PR TITLE
Provide error mapping for `maliput::api::rules` module.

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -181,15 +181,18 @@ pub mod ffi {
 
         // RoadRulebook bindings definitions.
         type RoadRulebook;
-        fn RoadRulebook_GetDiscreteValueRule(book: &RoadRulebook, rule_id: &String) -> UniquePtr<DiscreteValueRule>;
-        fn RoadRulebook_GetRangeValueRule(book: &RoadRulebook, rule_id: &String) -> UniquePtr<RangeValueRule>;
+        fn RoadRulebook_GetDiscreteValueRule(
+            book: &RoadRulebook,
+            rule_id: &String,
+        ) -> Result<UniquePtr<DiscreteValueRule>>;
+        fn RoadRulebook_GetRangeValueRule(book: &RoadRulebook, rule_id: &String) -> Result<UniquePtr<RangeValueRule>>;
         fn RoadRulebook_Rules(book: &RoadRulebook) -> UniquePtr<QueryResults>;
         #[allow(clippy::needless_lifetimes)]
         fn RoadRulebook_FindRules(
             book: &RoadRulebook,
             ranges: &Vec<ConstLaneSRangeRef>,
             tolerance: f64,
-        ) -> UniquePtr<QueryResults>;
+        ) -> Result<UniquePtr<QueryResults>>;
 
         // DiscreteValueRule::DiscreteValue bindings definitions.
         type DiscreteValueRuleDiscreteValue;

--- a/maliput/examples/06_road_rulebook.rs
+++ b/maliput/examples/06_road_rulebook.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &String::from("1_0_1"),
         &maliput::api::SRange::new(0.0, lane_1_0_1.length()),
     )];
-    let rules_at_1_0_1 = rulebook.find_rules(&ranges_to_find_rules, 1e-3);
+    let rules_at_1_0_1 = rulebook.find_rules(&ranges_to_find_rules, 1e-3)?;
     let discrete_value_rules_at_1_0_1 = rules_at_1_0_1.discrete_value_rules;
     println!("All Discrete Value Rules at 1_0_1:");
     for (rule_id, _) in discrete_value_rules_at_1_0_1.iter() {
@@ -135,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     // Alternatively, if you know the type of the rule and the lane id, you can use the `get_discrete_value_rule` method to get the rule directly.
     let expected_rule_id = String::from("Direction-Usage Rule Type/1_0_1");
-    let rule = rulebook.get_discrete_value_rule(&expected_rule_id);
+    let rule = rulebook.get_discrete_value_rule(&expected_rule_id)?;
     assert_eq!(rule.id(), expected_rule_id);
     assert_eq!(rule.type_id(), "Direction-Usage Rule Type");
     let states = rule.states();

--- a/maliput/examples/08_direction_usage_rule.rs
+++ b/maliput/examples/08_direction_usage_rule.rs
@@ -28,10 +28,12 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use maliput::common::MaliputError;
+
 fn get_direction_usage_rule_for_lane(
     lane_id: &str,
     rulebook: &maliput::api::rules::RoadRulebook,
-) -> Option<maliput::api::rules::DiscreteValueRule> {
+) -> Result<maliput::api::rules::DiscreteValueRule, MaliputError> {
     let direction_usage_rule_type = "Direction-Usage Rule Type";
     // We rely on maliput_malidrive which define the rule id as:
     // "<rule_type>/<lane_id>"
@@ -39,11 +41,7 @@ fn get_direction_usage_rule_for_lane(
     // "Direction-Usage Rule Type/<lane_id>"
     // So we can construct the rule id as follows:
     let rule_id = direction_usage_rule_type.to_string() + "/" + lane_id;
-    let rules = rulebook.rules();
-    let mut rule_ids = rules.discrete_value_rules.keys();
-    rule_ids.find(|id| *id == &rule_id)?;
-    let rule = rulebook.get_discrete_value_rule(&rule_id);
-    Some(rule)
+    rulebook.get_discrete_value_rule(&rule_id)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -68,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for lane in lanes {
         let lane_id = lane.id();
         let rule = get_direction_usage_rule_for_lane(&lane_id, &rulebook);
-        if let Some(rule) = rule {
+        if let Ok(rule) = rule {
             // Print the DiscreteValueRule for the lane.
             println!("Direction Usage Rule for lane {}:\n{:?}", lane_id, rule);
             // Print just the state for better showcase.

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -539,11 +539,13 @@ impl<'a> RoadRulebook<'a> {
         let range_value_rules_id = maliput_sys::api::rules::ffi::QueryResults_range_value_rules(&query_results_cpp);
         let mut dvr_map = std::collections::HashMap::new();
         for rule_id in discrete_value_rules_id {
+            // It is okay to unwrap here since we are iterating valid IDs obtained above.
             let rule = self.get_discrete_value_rule(&rule_id).unwrap();
             dvr_map.insert(rule.id(), rule);
         }
         let mut rvr_map = std::collections::HashMap::new();
         for rule_id in range_value_rules_id {
+            // It is okay to unwrap here since we are iterating valid IDs obtained above.
             let rule = self.get_range_value_rule(&rule_id).unwrap();
             rvr_map.insert(rule.id(), rule);
         }

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -28,6 +28,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::common::MaliputError;
+
 /// Interface for accessing the [TrafficLight] in the [super::RoadNetwork]
 pub struct TrafficLightBook<'a> {
     pub(super) traffic_light_book: &'a maliput_sys::api::rules::ffi::TrafficLightBook,
@@ -505,23 +507,26 @@ impl<'a> RoadRulebook<'a> {
     /// * `rule_id` - The id of the rule.
     /// ## Return
     /// The DiscreteValueRule with the given id.
-    pub fn get_discrete_value_rule(&self, rule_id: &String) -> DiscreteValueRule {
-        DiscreteValueRule {
+    pub fn get_discrete_value_rule(&self, rule_id: &String) -> Result<DiscreteValueRule, MaliputError> {
+        Ok(DiscreteValueRule {
             discrete_value_rule: maliput_sys::api::rules::ffi::RoadRulebook_GetDiscreteValueRule(
                 self.road_rulebook,
                 rule_id,
-            ),
-        }
+            )?,
+        })
     }
     /// Returns the RangeValueRule with the specified `id`.
     /// ## Arguments
     /// * `rule_id` - The id of the rule.
     /// ## Return
     /// The RangeValueRule with the given id.
-    pub fn get_range_value_rule(&self, rule_id: &String) -> RangeValueRule {
-        RangeValueRule {
-            range_value_rule: maliput_sys::api::rules::ffi::RoadRulebook_GetRangeValueRule(self.road_rulebook, rule_id),
-        }
+    pub fn get_range_value_rule(&self, rule_id: &String) -> Result<RangeValueRule, MaliputError> {
+        Ok(RangeValueRule {
+            range_value_rule: maliput_sys::api::rules::ffi::RoadRulebook_GetRangeValueRule(
+                self.road_rulebook,
+                rule_id,
+            )?,
+        })
     }
 
     /// Returns all the rules in the road rulebook.
@@ -534,12 +539,12 @@ impl<'a> RoadRulebook<'a> {
         let range_value_rules_id = maliput_sys::api::rules::ffi::QueryResults_range_value_rules(&query_results_cpp);
         let mut dvr_map = std::collections::HashMap::new();
         for rule_id in discrete_value_rules_id {
-            let rule = self.get_discrete_value_rule(&rule_id);
+            let rule = self.get_discrete_value_rule(&rule_id).unwrap();
             dvr_map.insert(rule.id(), rule);
         }
         let mut rvr_map = std::collections::HashMap::new();
         for rule_id in range_value_rules_id {
-            let rule = self.get_range_value_rule(&rule_id);
+            let rule = self.get_range_value_rule(&rule_id).unwrap();
             rvr_map.insert(rule.id(), rule);
         }
         QueryResults {
@@ -548,8 +553,7 @@ impl<'a> RoadRulebook<'a> {
         }
     }
 
-    pub fn find_rules(&self, ranges: &Vec<super::LaneSRange>, tolerance: f64) -> QueryResults {
-        // let mut ranges_cpp = cxx::CxxVector::new().pin_mut();
+    pub fn find_rules(&self, ranges: &Vec<super::LaneSRange>, tolerance: f64) -> Result<QueryResults, MaliputError> {
         let mut ranges_cpp = Vec::new();
         for range in ranges {
             ranges_cpp.push(maliput_sys::api::rules::ffi::ConstLaneSRangeRef {
@@ -557,25 +561,25 @@ impl<'a> RoadRulebook<'a> {
             });
         }
         let query_results_cpp =
-            maliput_sys::api::rules::ffi::RoadRulebook_FindRules(self.road_rulebook, &ranges_cpp, tolerance);
+            maliput_sys::api::rules::ffi::RoadRulebook_FindRules(self.road_rulebook, &ranges_cpp, tolerance)?;
 
         let discrete_value_rules_id =
             maliput_sys::api::rules::ffi::QueryResults_discrete_value_rules(&query_results_cpp);
         let range_value_rules_id = maliput_sys::api::rules::ffi::QueryResults_range_value_rules(&query_results_cpp);
         let mut dvr_map = std::collections::HashMap::new();
         for rule_id in discrete_value_rules_id {
-            let rule = self.get_discrete_value_rule(&rule_id);
+            let rule = self.get_discrete_value_rule(&rule_id)?;
             dvr_map.insert(rule.id(), rule);
         }
         let mut rvr_map = std::collections::HashMap::new();
         for rule_id in range_value_rules_id {
-            let rule = self.get_range_value_rule(&rule_id);
+            let rule = self.get_range_value_rule(&rule_id)?;
             rvr_map.insert(rule.id(), rule);
         }
-        QueryResults {
+        Ok(QueryResults {
             discrete_value_rules: dvr_map,
             range_value_rules: rvr_map,
-        }
+        })
     }
 }
 

--- a/maliput/tests/discrete_value_rule_test.rs
+++ b/maliput/tests/discrete_value_rule_test.rs
@@ -44,11 +44,17 @@ fn discrete_value_rule_test_api() {
     let expected_rule_id = String::from("Right-Of-Way Rule Type/WestToEastSouth");
     let expected_type_id = String::from("Right-Of-Way Rule Type");
     let rule = book.get_discrete_value_rule(&expected_rule_id);
+    assert!(rule.is_ok());
+    let rule = rule.unwrap();
     assert_eq!(rule.id(), expected_rule_id);
     assert_eq!(rule.type_id(), expected_type_id);
     let zone = rule.zone();
     let expected_zone_length = 15.;
     assert!((zone.length() - expected_zone_length).abs() < TOLERANCE);
+
+    let invalid_rule_id = String::from("Invalid Rule Type/InvalidRule");
+    let invalid_rule = book.get_discrete_value_rule(&invalid_rule_id);
+    assert!(invalid_rule.is_err());
 
     let states = rule.states();
     assert_eq!(states.len(), 2); // Go and Stop

--- a/maliput/tests/range_value_rule_test.rs
+++ b/maliput/tests/range_value_rule_test.rs
@@ -44,11 +44,17 @@ fn range_value_rule_test_api() {
     let expected_rule_id = String::from("Speed-Limit Rule Type/1_0_1_1");
     let expected_type_id = String::from("Speed-Limit Rule Type");
     let rule = book.get_range_value_rule(&expected_rule_id);
+    assert!(rule.is_ok());
+    let rule = rule.unwrap();
     assert_eq!(rule.id(), expected_rule_id);
     assert_eq!(rule.type_id(), expected_type_id);
     let zone = rule.zone();
     let expected_zone_length = 15.;
     assert!((zone.length() - expected_zone_length).abs() < TOLERANCE);
+
+    let invalid_rule_id = String::from("Invaliid Rule Type/InvalidRule");
+    let invalid_rule = book.get_range_value_rule(&invalid_rule_id);
+    assert!(invalid_rule.is_err());
 
     let states = rule.states();
     assert_eq!(states.len(), 1); // Only one speed limit state

--- a/maliput/tests/road_rulebook_test.rs
+++ b/maliput/tests/road_rulebook_test.rs
@@ -42,6 +42,8 @@ fn road_rulebook_test_api() {
     let expected_rule_id = String::from("Vehicle-Stop-In-Zone-Behavior Rule Type/WestToEastSouth");
     let expected_type_id = String::from("Vehicle-Stop-In-Zone-Behavior Rule Type");
     let rule = book.get_discrete_value_rule(&expected_rule_id);
+    assert!(rule.is_ok());
+    let rule = rule.unwrap();
     assert_eq!(rule.id(), expected_rule_id);
     assert_eq!(rule.type_id(), expected_type_id);
 
@@ -49,6 +51,8 @@ fn road_rulebook_test_api() {
     let expected_rule_id = String::from("Speed-Limit Rule Type/1_0_1_1");
     let expected_type_id = String::from("Speed-Limit Rule Type");
     let rule = book.get_range_value_rule(&expected_rule_id);
+    assert!(rule.is_ok());
+    let rule = rule.unwrap();
     assert_eq!(rule.id(), expected_rule_id);
     assert_eq!(rule.type_id(), expected_type_id);
 
@@ -72,7 +76,9 @@ fn road_rulebook_test_api() {
     let lane_s_range_1 = maliput::api::LaneSRange::new(&String::from("1_0_1"), &maliput::api::SRange::new(0.0, 100.0));
     let lane_s_range_2 = maliput::api::LaneSRange::new(&String::from("2_0_1"), &maliput::api::SRange::new(0.0, 200.0));
     let ranges = vec![lane_s_range_1, lane_s_range_2];
-    let rules: maliput::api::rules::QueryResults = book.find_rules(&ranges, 1e-3);
+    let rules = book.find_rules(&ranges, 1e-3);
+    assert!(rules.is_ok());
+    let rules = rules.unwrap();
     assert_eq!(rules.discrete_value_rules.len(), 4);
     assert_eq!(rules.range_value_rules.len(), 2);
 }


### PR DESCRIPTION
# 🎉 New feature

Relates to #183 

## Summary
Return `Result<(), MaliputError>` in the necessary bindings from `maliput::api::rules`.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
