### PR TITLE
Provide error mapping for `maliput::utility` module.

### DIFF
--- a/maliput-sys/src/utility/mod.rs
+++ b/maliput-sys/src/utility/mod.rs
@@ -97,6 +97,6 @@ pub mod ffi {
             dirpath: &String,
             fileroot: &String,
             features: &Features,
-        );
+        ) -> Result<()>;
     }
 }

--- a/maliput/src/utility/mod.rs
+++ b/maliput/src/utility/mod.rs
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::api::RoadNetwork;
+use crate::common::MaliputError;
 use std::error::Error;
 use std::fs::{create_dir_all, read_to_string, remove_file};
 use std::path::{Path, PathBuf};
@@ -55,12 +56,12 @@ pub fn generate_obj_file(
     dirpath: impl AsRef<Path>,
     fileroot: impl AsRef<str>,
     obj_features: &ObjFeatures,
-) -> Result<PathBuf, Box<dyn Error>> {
+) -> Result<PathBuf, MaliputError> {
     // Saves the complete path to the generated Wavefront file.
     let future_obj_file_path = dirpath.as_ref().join(fileroot.as_ref().to_string() + ".obj");
-    let dirpath = to_string(dirpath)?;
+    let dirpath = to_string(dirpath).map_err(|e| MaliputError::Other(e.to_string()))?;
     // Creates dirpath if does not exist.
-    create_dir_all(&dirpath)?;
+    create_dir_all(&dirpath).map_err(|e| MaliputError::Other(e.to_string()))?;
     let raw_rn = road_network.rn.as_ref();
     if let Some(raw_rn) = raw_rn {
         unsafe {
@@ -69,16 +70,18 @@ pub fn generate_obj_file(
                 &dirpath,
                 &fileroot.as_ref().to_string(),
                 obj_features,
-            );
+            )?;
         }
         // Verify if the file was created.
         if future_obj_file_path.is_file() && future_obj_file_path.with_extension("mtl").is_file() {
             Ok(future_obj_file_path)
         } else {
-            Result::Err(Box::from("Failed to generate the Wavefront files."))
+            Result::Err(MaliputError::Other(String::from(
+                "Failed to generate the Wavefront files.",
+            )))
         }
     } else {
-        Result::Err(Box::from("RoadNetwork is empty."))
+        Result::Err(MaliputError::AssertionError(String::from("RoadNetwork is empty.")))
     }
 }
 


### PR DESCRIPTION
# 🎉 New feature

Relates to #183 

## Summary
Return `Result<(), MaliputError>` in the necessary bindings from `maliput::utility`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.