### PR TITLE
maliput-rs more compliant with other bazel versions.

### DIFF
--- a/maliput-sys/src/math/mod.rs
+++ b/maliput-sys/src/math/mod.rs
@@ -72,11 +72,11 @@ pub mod ffi {
             m21: f64,
             m22: f64,
         ) -> UniquePtr<Matrix3>;
-        fn cofactor(self: &Matrix3, row: u64, col: u64) -> f64;
+        fn cofactor(self: &Matrix3, row: usize, col: usize) -> f64;
         fn determinant(self: &Matrix3) -> f64;
         fn is_singular(self: &Matrix3) -> bool;
-        fn Matrix3_row(m: &Matrix3, index: u64) -> UniquePtr<Vector3>;
-        fn Matrix3_col(m: &Matrix3, index: u64) -> UniquePtr<Vector3>;
+        fn Matrix3_row(m: &Matrix3, index: usize) -> UniquePtr<Vector3>;
+        fn Matrix3_col(m: &Matrix3, index: usize) -> UniquePtr<Vector3>;
         fn Matrix3_cofactor_matrix(m: &Matrix3) -> UniquePtr<Matrix3>;
         fn Matrix3_transpose(m: &Matrix3) -> UniquePtr<Matrix3>;
         fn Matrix3_equals(m: &Matrix3, other: &Matrix3) -> bool;

--- a/maliput/src/math/mod.rs
+++ b/maliput/src/math/mod.rs
@@ -230,7 +230,7 @@ impl Matrix3 {
         }
     }
     /// Get the cofactor of the `Matrix3` at the given `row` and `col`.
-    pub fn cofactor(&self, row: u64, col: u64) -> f64 {
+    pub fn cofactor(&self, row: usize, col: usize) -> f64 {
         self.m.cofactor(row, col)
     }
     /// Get the cofactor matrix of the `Matrix3`.
@@ -248,13 +248,13 @@ impl Matrix3 {
         self.m.is_singular()
     }
     /// Get the row at the given `index`.
-    pub fn row(&self, index: u64) -> Vector3 {
+    pub fn row(&self, index: usize) -> Vector3 {
         Vector3 {
             v: maliput_sys::math::ffi::Matrix3_row(&self.m, index),
         }
     }
     /// Get the column at the given `index`.
-    pub fn col(&self, index: u64) -> Vector3 {
+    pub fn col(&self, index: usize) -> Vector3 {
         Vector3 {
             v: maliput_sys::math::ffi::Matrix3_col(&self.m, index),
         }


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - Better resolve the paths in build.rs for the bazel artifacts so as to be compliant when using other bazel versions.
 - Bug fix: In maliput::math there were some methods that were mistakenly using u64 instead of usize.

All the credits go to _Marvin Strujik_

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
