### PR TITLE
Improves shared library handling.

### DIFF
--- a/maliput-sdk/BUILD.bazel
+++ b/maliput-sdk/BUILD.bazel
@@ -7,7 +7,6 @@
 # Libraries
 ###############################################################################
 
-# Dummy binary to force maliput to be downloaded from BCR.
 cc_binary(
     name = "maliput_sdk",
     visibility = ["//visibility:public"],
@@ -20,6 +19,16 @@ cc_binary(
         "@maliput//:geometry_base",
         "@maliput//:plugin",
         "@maliput//:utility",
+    ],
+    linkshared = True,
+    linkstatic = True,
+)
+
+# Dummy binary to force maliput_malidrive to be downloaded from BCR.
+cc_binary(
+    name = "maliput_malidrive_dummy",
+    visibility = ["//visibility:public"],
+    deps = [
         "@maliput_malidrive//:maliput_plugins/libmaliput_malidrive_road_network.so",
     ],
     data = [

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -9,5 +9,5 @@ module(
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.6.0")
-bazel_dep(name = "maliput_malidrive", version = "0.9.1")
+bazel_dep(name = "maliput", version = "1.7.0")
+bazel_dep(name = "maliput_malidrive", version = "0.10.0")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -28,6 +28,7 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 This package brings maliput-ecosystem and provides the path to where the installation is located.
 
  - For accessing it via `build.rs` file, some env var are provided:
+   - `MALIPUT_SDK_BIN_PATH`: Path to maliput-sdk's bazel binaries.
    - `MALIPUT_SDK_MALIPUT_BIN_PATH`: Path to maliput binaries.
    - `MALIPUT_SDK_MALIPUT_MALIDRIVE_BIN_PATH`: Path to maliput_malidrive binaries.
    - `MALIPUT_SDK_MALIPUT_MALIDRIVE_PLUGIN_PATH`: Path to maliput_malidrive road network plugin.

--- a/maliput-sdk/build.rs
+++ b/maliput-sdk/build.rs
@@ -202,11 +202,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     // ************* maliput_malidrive resource files ************* //
     // Set library file name based on OS
     let lib_dir = if cfg!(target_os = "macos") {
-        "libmaliput_sdk.dylib.runfiles"
+        "libmaliput_malidrive_dummy.dylib.runfiles"
     } else if cfg!(target_os = "linux") {
-        "libmaliput_sdk.so.runfiles"
+        "libmaliput_malidrive_dummy.so.runfiles"
     } else {
-        "maliput_sdk.dll.runfiles"
+        "maliput_malidrive_dummy.dll.runfiles"
     };
 
     let maliput_malidrive_resource_path = resolve_bazel_package_path(
@@ -237,6 +237,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Environment variable to pass down to dependent crates:
     // See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
     println!("cargo:root={}", out_dir.display()); //> Accessed as MALIPUT_SDK_ROOT
+    println!("cargo:bin_path={}", bazel_bin_dir.display()); //> Accessed as MALIPUT_SDK_BIN_PATH
     println!("cargo:maliput_bin_path={}", maliput_bin_path.display()); //> Accessed as MALIPUT_SDK_MALIPUT_BIN_PATH
     println!(
         "cargo:maliput_malidrive_bin_path={}",

--- a/maliput-sys/build.rs
+++ b/maliput-sys/build.rs
@@ -49,22 +49,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=src/plugin/plugin.h");
     println!("cargo:rerun-if-changed=src/utility/mod.rs");
     println!("cargo:rerun-if-changed=src/utility/utility.h");
+    // Link to maliput_sdk.so which contains a bundle of all maliput libs.
+    let maliput_sdk_bin_path =
+        PathBuf::from(env::var("DEP_MALIPUT_SDK_BIN_PATH").expect("DEP_MALIPUT_SDK_BIN_PATH not set"));
 
-    let maliput_bin_path =
-        PathBuf::from(env::var("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH").expect("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH not set"));
-
-    println!("cargo:rustc-link-search=native={}", maliput_bin_path.display());
-
-    // Link to all the libraries in the bazel-bin folder.
-    // The order of these is important! Otherwise, we get undefined reference errors.
-    println!("cargo:rustc-link-lib=math");
-    println!("cargo:rustc-link-lib=common");
-    println!("cargo:rustc-link-lib=drake");
-    println!("cargo:rustc-link-lib=geometry_base");
-    println!("cargo:rustc-link-lib=plugin");
-    println!("cargo:rustc-link-lib=utility");
-    println!("cargo:rustc-link-lib=base");
-    println!("cargo:rustc-link-lib=api");
+    println!("cargo:rustc-link-search=native={}", maliput_sdk_bin_path.display());
+    println!("cargo:rustc-link-lib=maliput_sdk");
 
     cxx_build::bridges([
         "src/math/mod.rs",

--- a/maliput-sys/src/cxx_utils/error_handling.h
+++ b/maliput-sys/src/cxx_utils/error_handling.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include <maliput/common/assertion_error.h>
+#include <maliput/common/error.h>
 
 #include <rust/cxx.h>
 

--- a/maliput/build.rs
+++ b/maliput/build.rs
@@ -40,11 +40,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // We set two arguments: rpath and link-search. The rpath is intended for the final binary to link to the library, and link-search allows Cargo to locate the library.
     //
     // See: https://github.com/rust-lang/cargo/issues/5077
-    let maliput_bin_path =
-        PathBuf::from(env::var("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH").expect("DEP_MALIPUT_SDK_MALIPUT_BIN_PATH not set"));
-
-    println!("cargo:rustc-link-search=native={}", maliput_bin_path.display());
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", maliput_bin_path.display());
-
+    let maliput_sdk_out_root = PathBuf::from(env::var("DEP_MALIPUT_SDK_ROOT").expect("DEP_MALIPUT_SDK_ROOT not set"));
+    let maliput_sdk_so_folder = maliput_sdk_out_root.join("bazel_output_base").join("bazel-bin");
+    println!("cargo:rustc-link-search=native={}", maliput_sdk_so_folder.display());
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", maliput_sdk_so_folder.display());
     Ok(())
 }


### PR DESCRIPTION
# 🎉 New feature

:exclamation: Depends on:
 - https://github.com/maliput/maliput/pull/670
 - https://github.com/maliput/maliput_malidrive/pull/339
 - [x] new maliput bazel release
 - [x] new maliput_malidrive bazel release

## Summary
Introduces several changes to better handling maliput (cpp) libs in a static way.
 - libmaliput_sdk.so contains maliput libraries.
 - libmaliput_malidrive_road_network.so is the malidrive pluguin for maliput.

Therefore, when deploying, only those two libs should be copied / installed.

