### PR TITLE
maliput-sdk: Clean up dummy lib bazel bin.

### DIFF
--- a/maliput-sdk/BUILD.bazel
+++ b/maliput-sdk/BUILD.bazel
@@ -24,16 +24,15 @@ cc_binary(
     linkstatic = True,
 )
 
-# Dummy binary to force maliput_malidrive to be downloaded from BCR.
-cc_binary(
+# Dummy lib to force maliput_malidrive to be downloaded from BCR.
+cc_library(
     name = "maliput_malidrive_dummy",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
         "@maliput_malidrive//:maliput_plugins/libmaliput_malidrive_road_network.so",
     ],
     data = [
         "@maliput_malidrive//resources:all"
     ],
-    linkshared = True,
     linkstatic = False
 )


### PR DESCRIPTION
# 🎉 New feature

## Summary
Avoid installing dummy library to avoid misuse in downstream packages.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
