### PR TITLE
Prepare for maliput-sdk release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "maliput-sys"

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,9 +5,9 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.8.0",
+    version = "0.8.1",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "maliput", version = "1.7.0")
-bazel_dep(name = "maliput_malidrive", version = "0.10.0")
+bazel_dep(name = "maliput", version = "1.7.1")
+bazel_dep(name = "maliput_malidrive", version = "0.10.1")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -20,8 +20,8 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 
 | BCR Module | Current version |
 |------------|---------|
-| [maliput](https://registry.bazel.build/modules/maliput)    | 1.7.0 |
-| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.10.0 |
+| [maliput](https://registry.bazel.build/modules/maliput)    | 1.7.1 |
+| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.10.1 |
 
 ## Usage
 


### PR DESCRIPTION
# 🎈 Release

## Summary
* `maliput-sdk` patch release pointing to `maliput` 1.7.1 and `maliput_malidrive` 0.10.1.

## After PR is merged
* [x] `cargo publish --dry-run --verbose --package maliput-sdk`

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
