### PR TITLE
Add `RuleType` API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -361,6 +361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +462,8 @@ dependencies = [
  "cxx",
  "maliput-sdk",
  "maliput-sys",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -657,6 +665,24 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/maliput/maliput-rs"
 cxx = { version = "1.0.78" }
 cxx-build = { version = "1.0.78" }
 clap = { version = "~4.3" }
+strum = { version = "0.27" }
+strum_macros = { version = "0.27" }
 thiserror = { version = "1.0" }
 
 maliput-sdk = { version = "0.9", path = "maliput-sdk" }

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -19,6 +19,8 @@ clap = { workspace = true, features = ["derive"] }
 cxx = { workspace = true }
 maliput-sdk = { workspace = true }
 maliput-sys = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/maliput/examples/08_direction_usage_rule.rs
+++ b/maliput/examples/08_direction_usage_rule.rs
@@ -28,21 +28,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use maliput::common::MaliputError;
-
-fn get_direction_usage_rule_for_lane(
-    lane_id: &str,
-    rulebook: &maliput::api::rules::RoadRulebook,
-) -> Result<maliput::api::rules::DiscreteValueRule, MaliputError> {
-    let direction_usage_rule_type = "Direction-Usage Rule Type";
-    // We rely on maliput_malidrive which define the rule id as:
-    // "<rule_type>/<lane_id>"
-    // And for the Direction Usage Rule Type, it is defined as:
-    // "Direction-Usage Rule Type/<lane_id>"
-    // So we can construct the rule id as follows:
-    let rule_id = direction_usage_rule_type.to_string() + "/" + lane_id;
-    rulebook.get_discrete_value_rule(&rule_id)
-}
+use maliput::api::rules::RuleType;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use maliput::api::RoadNetwork;
@@ -65,8 +51,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Let's find the direction usage rule for all the lanes
     let lanes = rg.get_lanes();
     for lane in lanes {
+        let rule_type = RuleType::DirectionUsage;
         let lane_id = lane.id();
-        let rule = get_direction_usage_rule_for_lane(&lane_id, &rulebook);
+        let rule = rulebook.get_discrete_value_rule(&rule_type.get_rule_id(&lane_id));
         if let Ok(rule) = rule {
             // Print the DiscreteValueRule for the lane.
             println!("Direction Usage Rule for lane {}:\n{:?}", lane_id, rule);

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -802,6 +802,47 @@ impl RangeValueRule {
     }
 }
 
+/// Defines a Rule Type.
+///
+/// # RuleType
+///
+/// [RuleType]s provide a way of obtaining a rule type's string defined in
+/// maliput's backend. Since new rule types can be created in a custom manner,
+/// [RuleType] only holds the most common types which are already defined in
+/// the backend.
+pub enum RuleType {
+    DirectionUsage,
+    RightOfWay,
+    VehicleStopInZoneBehavior,
+    SpeedLimit,
+}
+
+impl std::fmt::Display for RuleType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::DirectionUsage => write!(f, "Direction-Usage Rule Type"),
+            Self::RightOfWay => write!(f, "Right-Of-Way Rule Type"),
+            Self::VehicleStopInZoneBehavior => write!(f, "Vehicle-Stop-In-Zone-Behavior Rule Type"),
+            Self::SpeedLimit => write!(f, "Speed-Limit Rule Type"),
+        }
+    }
+}
+
+impl RuleType {
+    /// Gets the Rule ID for the [RuleType] and `lane_id`.
+    ///
+    /// # Arguments
+    /// - `lane_id` - The lane ID to get the rule ID from.
+    ///
+    /// # Returns
+    /// A rule ID formatted the way the backend defines it.
+    pub fn get_rule_id(&self, lane_id: &str) -> String {
+        // We rely on maliput_malidrive which define the rule id as:
+        // "<rule_type>/<lane_id>"
+        self.to_string() + "/" + lane_id
+    }
+}
+
 /// Defines a base state for a rule.
 ///
 /// # RuleStateBase

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::common::MaliputError;
+use strum_macros::{Display, IntoStaticStr};
 
 /// Interface for accessing the [TrafficLight] in the [super::RoadNetwork]
 pub struct TrafficLightBook<'a> {
@@ -810,22 +811,16 @@ impl RangeValueRule {
 /// maliput's backend. Since new rule types can be created in a custom manner,
 /// [RuleType] only holds the most common types which are already defined in
 /// the backend.
+#[derive(Display, IntoStaticStr)]
 pub enum RuleType {
+    #[strum(serialize = "Direction-Usage Rule Type")]
     DirectionUsage,
+    #[strum(serialize = "Right-Of-Way Rule Type")]
     RightOfWay,
+    #[strum(serialize = "Vehicle-Stop-In-Zone-Behavior Rule Type")]
     VehicleStopInZoneBehavior,
+    #[strum(serialize = "Speed-Limit Rule Type")]
     SpeedLimit,
-}
-
-impl std::fmt::Display for RuleType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::DirectionUsage => write!(f, "Direction-Usage Rule Type"),
-            Self::RightOfWay => write!(f, "Right-Of-Way Rule Type"),
-            Self::VehicleStopInZoneBehavior => write!(f, "Vehicle-Stop-In-Zone-Behavior Rule Type"),
-            Self::SpeedLimit => write!(f, "Speed-Limit Rule Type"),
-        }
-    }
 }
 
 impl RuleType {

--- a/maliput/tests/rule_type_tests.rs
+++ b/maliput/tests/rule_type_tests.rs
@@ -1,0 +1,55 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, Woven by Toyota.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use maliput::api::rules::RuleType;
+
+#[test]
+fn rule_type_api() {
+    let rule_type = RuleType::DirectionUsage;
+    assert_eq!(rule_type.to_string(), "Direction-Usage Rule Type");
+    assert_eq!(rule_type.get_rule_id("lane_id"), "Direction-Usage Rule Type/lane_id");
+    let rule_type = RuleType::RightOfWay;
+    assert_ne!(rule_type.to_string(), "Direction-Usage Rule Type");
+    assert_eq!(rule_type.to_string(), "Right-Of-Way Rule Type");
+    assert_eq!(rule_type.get_rule_id("lane_id"), "Right-Of-Way Rule Type/lane_id");
+    let rule_type = RuleType::VehicleStopInZoneBehavior;
+    assert_ne!(rule_type.to_string(), "Right-Of-Way Rule Type");
+    assert_eq!(rule_type.to_string(), "Vehicle-Stop-In-Zone-Behavior Rule Type");
+    assert_eq!(
+        rule_type.get_rule_id("lane_id"),
+        "Vehicle-Stop-In-Zone-Behavior Rule Type/lane_id"
+    );
+    let rule_type = RuleType::SpeedLimit;
+    assert_ne!(rule_type.to_string(), "Vehicle-Stop-In-Zone-Behavior Rule Type");
+    assert_eq!(rule_type.to_string(), "Speed-Limit Rule Type");
+    assert_eq!(rule_type.get_rule_id("lane_id"), "Speed-Limit Rule Type/lane_id");
+    let rule_type = RuleType::DirectionUsage;
+    assert_ne!(rule_type.to_string(), "Speed-Limit Rule Type");
+}

--- a/maliput/tests/rule_type_tests.rs
+++ b/maliput/tests/rule_type_tests.rs
@@ -52,4 +52,13 @@ fn rule_type_api() {
     assert_eq!(rule_type.get_rule_id("lane_id"), "Speed-Limit Rule Type/lane_id");
     let rule_type = RuleType::DirectionUsage;
     assert_ne!(rule_type.to_string(), "Speed-Limit Rule Type");
+
+    let rule_str: &'static str = RuleType::DirectionUsage.into();
+    assert_eq!(rule_str, "Direction-Usage Rule Type");
+    let rule_str: &'static str = RuleType::RightOfWay.into();
+    assert_eq!(rule_str, "Right-Of-Way Rule Type");
+    let rule_str: &'static str = RuleType::VehicleStopInZoneBehavior.into();
+    assert_eq!(rule_str, "Vehicle-Stop-In-Zone-Behavior Rule Type");
+    let rule_str: &'static str = RuleType::SpeedLimit.into();
+    assert_eq!(rule_str, "Speed-Limit Rule Type");
 }


### PR DESCRIPTION
# 🎉 New feature

Relates to https://github.com/maliput/maliput/issues/664 and https://github.com/maliput/maliput-rs/issues/191

## Summary
Add RuleType API to get rule type strings and rule IDs matching the backend without having to pull those out of a tophat :magic_wand: :tophat: :rabbit: . 

## Test it
Example 08 has been updated to use the new API.
```
cargo run -p maliput --example 08_direction_usage_rule
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
