### PR TITLE
Improve `to_road_position` API.

### DIFF
--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -309,9 +309,9 @@ impl<'a> RoadGeometry<'a> {
         let distance = maliput_sys::api::ffi::RoadPositionResult_distance(&rpr);
         if distance > self.linear_tolerance() {
             return Err(MaliputError::Other(format!(
-                "InertialPosition {} does not correspond to a RoadPosition. It is off by {}m to the closest road at {}.",
+                "InertialPosition {} does not correspond to a RoadPosition. It is off by {}m to the closest lane {} at {}.",
                 maliput_sys::api::ffi::InertialPosition_to_str(&inertial_position.ip),
-                distance, road_position.to_inertial_position())));
+                distance, road_position.lane().id(), road_position.pos())));
         }
 
         let lane_position =


### PR DESCRIPTION
# 🎉 New feature

## Summary
* Rename `RoadPositionResult` and `LanePositionResult` to `RoadPositionQuery` and `LanePositionQuery` to avoid colliding with a Rust naming convention that wraps a Result in a type.
* Improve `to_road_position()` docs to make more emphasis that it deals with a 3D road geometry.
* Implement new api `to_road_position_surface()` that takes an `InertialPosition` and returns a `RoadPosition` on top of the `RoadGeometry` surface.
  * Added a usage example in the method docstring.
  * Added tests.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
