### PR TITLE
Creates dummy link from maliput_sdk to maliput_malidrive plugin

### DIFF
--- a/maliput-sdk/BUILD.bazel
+++ b/maliput-sdk/BUILD.bazel
@@ -7,6 +7,14 @@
 # Libraries
 ###############################################################################
 
+# Import the pre-built shared library
+cc_import(
+    name = "malidrive_plugin",
+    # Path to the .so file relative to this BUILD file
+    shared_library = "@maliput_malidrive//:maliput_plugins/libmaliput_malidrive_road_network.so",
+    visibility = ["//visibility:public"],
+)
+
 cc_binary(
     name = "maliput_sdk",
     visibility = ["//visibility:public"],
@@ -19,6 +27,7 @@ cc_binary(
         "@maliput//:geometry_base",
         "@maliput//:plugin",
         "@maliput//:utility",
+        ":malidrive_plugin",
     ],
     linkshared = True,
     linkstatic = True,

--- a/maliput/build.rs
+++ b/maliput/build.rs
@@ -44,6 +44,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let maliput_sdk_so_folder = maliput_sdk_out_root.join("bazel_output_base").join("bazel-bin");
     println!("cargo:rustc-link-search=native={}", maliput_sdk_so_folder.display());
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}", maliput_sdk_so_folder.display());
+    let maliput_malidrive_plugin_path = PathBuf::from(
+        env::var("DEP_MALIPUT_SDK_MALIPUT_MALIDRIVE_PLUGIN_PATH")
+            .expect("DEP_MALIPUT_SDK_MALIPUT_MALIDRIVE_PLUGIN_PATH not set"),
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        maliput_malidrive_plugin_path.display()
+    );
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+        maliput_malidrive_plugin_path.display()
+    );
 
     // Environment variable to pass down to dependent crates:
     // See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
@@ -52,5 +64,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     //  - Downstream crates might not have rpath set correctly to find the .so files.
     //  - Cargo doesn't propagate the crate's environment variables to higher-level crates.
     println!("cargo:sdk_root_fw={}", maliput_sdk_so_folder.display()); //> Accessed as DEP_MALIPUT_SDK_ROOT_FW
+    println!(
+        "cargo:sdk_malidrive_plugin_path={}",
+        maliput_malidrive_plugin_path.display()
+    ); //> Accessed as DEP_MALIPUT_SDK_MALIDRIVE_PLUGIN_PATH
     Ok(())
 }

--- a/maliput/src/api/mod.rs
+++ b/maliput/src/api/mod.rs
@@ -92,14 +92,15 @@ impl RoadNetwork {
         for (key, value) in properties.iter() {
             properties_vec.push(format!("{}:{}", key, value));
         }
-        // Append the maliput_malidrive plugin path to MALIPUT_PLUGIN_PATH.
         // If MALIPUT_PLUGIN_PATH is not set, it will be created.
-        let malidrive_plugin_path = maliput_sdk::get_maliput_malidrive_plugin_path();
         let new_path = match std::env::var_os("MALIPUT_PLUGIN_PATH") {
             Some(current_path) => {
-                let mut paths = std::env::split_paths(&current_path).collect::<Vec<_>>();
-                paths.push(malidrive_plugin_path);
-                std::env::join_paths(paths).unwrap()
+                // Add the maliput_malidrive plugin path obtained from maliput_sdk to MALIPUT_PLUGIN_PATH.
+                // This is added first in the list as the plugins are loaded sequentally and we
+                // want this to be used only when no others are present. (typically in dev mode).
+                let mut new_paths = vec![maliput_sdk::get_maliput_malidrive_plugin_path()];
+                new_paths.extend(std::env::split_paths(&current_path).collect::<Vec<_>>());
+                std::env::join_paths(new_paths).unwrap()
             }
             None => maliput_sdk::get_maliput_malidrive_plugin_path().into(),
         };


### PR DESCRIPTION
## Summary
 - Adds dummy link between maliput-sdk and maliput-malidrive plugin so.
 - Modifies the ordering of the plugin path that is added automatically when working in development, making this the least important reference.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)




