### PR TITLE
Prepare for release `0.10.0`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maliput"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "clap 4.3.24",
  "criterion",
@@ -469,11 +469,11 @@ dependencies = [
 
 [[package]]
 name = "maliput-sdk"
-version = "0.9.1"
+version = "0.10.0"
 
 [[package]]
 name = "maliput-sys"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ strum = { version = "0.27" }
 strum_macros = { version = "0.27" }
 thiserror = { version = "1.0" }
 
-maliput-sdk = { version = "0.9", path = "maliput-sdk" }
-maliput-sys = { version = "0.9", path = "maliput-sys" }
+maliput-sdk = { version = "0.10", path = "maliput-sdk" }
+maliput-sys = { version = "0.10", path = "maliput-sys" }

--- a/maliput-sdk/Cargo.toml
+++ b/maliput-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sdk"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "Vendor for maliput libraries."

--- a/maliput-sdk/MODULE.bazel
+++ b/maliput-sdk/MODULE.bazel
@@ -5,7 +5,7 @@ Maliput SDK!
 module(
     name = "maliput_sdk",
     compatibility_level = 1,
-    version = "0.9.1",
+    version = "0.10.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/maliput-sdk/README.md
+++ b/maliput-sdk/README.md
@@ -20,8 +20,8 @@ _Note: What is maliput? Refer to https://maliput.readthedocs.org._
 
 | BCR Module | Current version |
 |------------|---------|
-| [maliput](https://registry.bazel.build/modules/maliput)    | 1.7.2 |
-| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.11.1 |
+| [maliput](https://registry.bazel.build/modules/maliput)    | 1.8.2 |
+| [maliput_malidrive](https://registry.bazel.build/modules/maliput_malidrive) | 0.12.1 |
 
 ## Usage
 

--- a/maliput-sys/Cargo.toml
+++ b/maliput-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput-sys"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["external-ffi-bindings", "simulation"]
 description = "FFI Rust bindings for maliput"

--- a/maliput/Cargo.toml
+++ b/maliput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maliput"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Franco Cipollone <franco.c@ekumenlabs.com>"]
 categories = ["simulation"]
 description = "Rust API for maliput"


### PR DESCRIPTION
# 🎈 Release

## Summary
* Point to `maliput` 1.8.2 version: https://github.com/maliput/maliput/pull/685
* Point to `maliput_malidrive` 0.12.1 version: https://github.com/maliput/maliput_malidrive/pull/353
* https://github.com/maliput/maliput-rs/pull/214
* https://github.com/maliput/maliput-rs/pull/217
* https://github.com/maliput/maliput-rs/pull/218
* https://github.com/maliput/maliput-rs/pull/219

## After PR is merged
* [ ] `cargo publish --dry-run --verbose --package maliput-sdk`
* [ ] `cargo publish --dry-run --verbose --package maliput-sys`
* [ ] `cargo publish --dry-run --verbose --package maliput`

## Checklist
- [x] Signed all commits for DCO
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
