### PR TITLE
Add `RuleRegistry.get_possible_states_of_rule_type` API.

### DIFF
--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -541,8 +541,8 @@ pub struct RuleRegistry<'a> {
     pub(super) rule_registry: &'a maliput_sys::api::rules::ffi::RuleRegistry,
 }
 
-/// Represents the value types of rules the [RuleRegistry] can contain.
-pub enum RuleValueTypes {
+/// Represents the rule values the [RuleRegistry] can contain by their Discrete or Range type.
+pub enum RuleValuesByType {
     DiscreteValues(Vec<DiscreteValue>),
     Ranges(Vec<Range>),
 }
@@ -624,12 +624,15 @@ impl<'a> RuleRegistry<'a> {
     /// * `rule_type_id` - The id of the rule type.
     ///
     /// # Returns
-    /// An `Option` containing a [RuleValueTypes] enum with either a vector of [Range]s or a
+    /// An `Option` containing a [RuleValuesByType] enum with either a vector of [Range]s or a
     /// vector of [DiscreteValue]s. Returns `None` if the `rule_type_id` is not found.
-    pub fn get_possible_states_of_rule_type(&self, rule_type_id: String) -> Option<RuleValueTypes> {
+    pub fn get_possible_states_of_rule_type(&self, rule_type_id: String) -> Option<RuleValuesByType> {
         if let Some(ranges) = self.range_values_by_type(rule_type_id.clone()) {
-            Some(RuleValueTypes::Ranges(ranges))
-        } else { self.discrete_values_by_type(rule_type_id).map(RuleValueTypes::DiscreteValues) }
+            Some(RuleValuesByType::Ranges(ranges))
+        } else {
+            self.discrete_values_by_type(rule_type_id)
+                .map(RuleValuesByType::DiscreteValues)
+        }
     }
 }
 

--- a/maliput/tests/rule_registry_test.rs
+++ b/maliput/tests/rule_registry_test.rs
@@ -28,7 +28,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use maliput::api::rules::{RuleType, RuleValueTypes};
+use maliput::api::rules::{RuleType, RuleValuesByType};
 
 mod common;
 
@@ -66,11 +66,11 @@ fn rule_registry_test() {
     let rule_value_types = rule_registry.get_possible_states_of_rule_type(RuleType::RightOfWay.to_string());
     assert!(rule_value_types.is_some());
     let rule_value_types = rule_value_types.unwrap();
-    assert!(matches!(rule_value_types, RuleValueTypes::DiscreteValues(_)));
+    assert!(matches!(rule_value_types, RuleValuesByType::DiscreteValues(_)));
     let rule_value_types = rule_registry.get_possible_states_of_rule_type(RuleType::SpeedLimit.to_string());
     assert!(rule_value_types.is_some());
     let rule_value_types = rule_value_types.unwrap();
-    assert!(matches!(rule_value_types, RuleValueTypes::Ranges(_)));
+    assert!(matches!(rule_value_types, RuleValuesByType::Ranges(_)));
 
     assert!(rule_registry
         .get_possible_states_of_rule_type("InvalidRuleType".to_string())


### PR DESCRIPTION
# 🎉 New feature

Relates to #227 and #235

## Summary
Adds API to get all possible rule values of a rule type by using the current Rust API.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
