### PR TITLE
Binding and API for FindPhaseRing.

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -255,6 +255,7 @@ pub mod ffi {
         type PhaseRingBook;
         fn PhaseRingBook_GetPhaseRingsId(book: &PhaseRingBook) -> Vec<String>;
         fn PhaseRingBook_GetPhaseRing(book: &PhaseRingBook, id: &String) -> UniquePtr<PhaseRing>;
+        fn PhaseRingBook_FindPhaseRing(book: &PhaseRingBook, rule_id: &String) -> UniquePtr<PhaseRing>;
 
         // RuleRegistry bindings definitions.
         type RuleRegistry;

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -373,6 +373,14 @@ std::unique_ptr<PhaseRing> PhaseRingBook_GetPhaseRing(const PhaseRingBook& phase
   return nullptr;
 }
 
+std::unique_ptr<PhaseRing> PhaseRingBook_FindPhaseRing(const PhaseRingBook& phase_ring_book, const rust::String& rule_id) {
+  const auto phase_ring = phase_ring_book.FindPhaseRing(Rule::Id{std::string(rule_id)});
+  if (phase_ring.has_value()) {
+    return std::make_unique<PhaseRing>(phase_ring.value());
+  }
+  return nullptr;
+}
+
 std::unique_ptr<std::vector<DiscreteValueRuleType>> RuleRegistry_DiscreteValueRuleTypes(const RuleRegistry& rule_registry) {
   const auto discrete_value_rule_types_cpp = rule_registry.DiscreteValueRuleTypes();
   std::vector<DiscreteValueRuleType> discrete_value_rule_types;

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -1142,6 +1142,21 @@ impl<'a> PhaseRingBook<'a> {
         }
         Some(PhaseRing { phase_ring })
     }
+
+    /// Finds the [PhaseRing] that contains the rule with the specified `rule_id`.
+    ///
+    /// # Arguments
+    /// * `rule_id` - The id of the rule.
+    ///
+    /// # Returns
+    /// The [PhaseRing] that contains the rule with the given id or `None` if no [PhaseRing] is found.
+    pub fn find_phase_ring(&self, rule_id: &String) -> Option<PhaseRing> {
+        let phase_ring = maliput_sys::api::rules::ffi::PhaseRingBook_FindPhaseRing(self.phase_ring_book, rule_id);
+        if phase_ring.is_null() {
+            return None;
+        }
+        Some(PhaseRing { phase_ring })
+    }
 }
 
 // Auxiliary method to create a [Vec<Range>] from a [cxx::Vector<RangeValueRuleRange>].

--- a/maliput/tests/phase_ring_book_test.rs
+++ b/maliput/tests/phase_ring_book_test.rs
@@ -53,4 +53,9 @@ fn phase_ring_book_test() {
     assert!(phase.is_some());
     let phase = phase.unwrap();
     assert_eq!(phase.id(), "AllGoPhase".to_string());
+
+    let phase_ring = phase_ring_book.find_phase_ring(&"Right-Of-Way Rule Type/WestToEastSouth".to_string());
+    assert!(phase_ring.is_some());
+    let phase_ring = phase_ring.unwrap();
+    assert!(!phase_ring.phases().is_empty());
 }


### PR DESCRIPTION
# 🎉 New feature

Relates to #230 and #237 

## Summary
Adds
- Binding for `FindPhaseRing` based on a rule ID.
- `find_phase_ring` API.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
