### PR TITLE
Update macOS runner version to macos-14

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -15,7 +15,7 @@ jobs:
   build_and_test:
     if: contains(github.event.pull_request.labels.*.name, 'do-macos-build') || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Build & Test
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
