### PR TITLE
clap: relax version bounds for clap to allow newer versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/maliput/maliput-rs"
 [workspace.dependencies]
 cxx = { version = "1.0.187" }
 cxx-build = { version = "1.0.187" }
-clap = { version = "~4.3" }
+clap = { version = "4.3" }
 strum = { version = "0.27" }
 strum_macros = { version = "0.27" }
 thiserror = { version = "1.0" }


### PR DESCRIPTION
# Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This commit updates the version bounds for the `clap` dependency from the version range `~4.3` to the version range `4.3` which allows Cargo to resolve for newer versions of clap when depending on maliput.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests (no code was changed)
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.