### PR TITLE
API for TrafficSign dependency.

### DIFF
--- a/maliput/examples/15_traffic_sign.rs
+++ b/maliput/examples/15_traffic_sign.rs
@@ -149,6 +149,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // other roads that point to the same sign ID.
         println!("    related_lanes: {:?}", sign.related_lanes());
 
+        // dependent_signs lists IDs of signs that depend on this sign (if any).
+        println!("    dependent_signs: {:?}", sign.dependent_signs());
+
         // The bounding box describes the sign's oriented bounding volume in the
         // inertial frame.  get_vertices() always returns 8 corner points.
         let bb = sign.bounding_box();

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -3096,6 +3096,12 @@ impl<'a> TrafficSign<'a> {
             .map(|p| (p.key, p.value))
             .collect()
     }
+
+    /// Returns the [TrafficSign]s' IDs that depend on this sign, if any.
+    /// For example, a "Stop" sign may have an associated "All way" sign.
+    pub fn dependent_signs(&self) -> Vec<String> {
+        vec![]
+    }
 }
 
 #[cfg(test)]

--- a/maliput/tests/traffic_sign_tests.rs
+++ b/maliput/tests/traffic_sign_tests.rs
@@ -191,3 +191,23 @@ fn traffic_sign_book_find_by_type_test() {
     let yield_signs = book.find_by_type(&maliput::api::rules::TrafficSignType::Yield);
     assert!(yield_signs.is_empty());
 }
+
+#[test]
+fn traffic_sign_dependent_signs_test() {
+    let road_network = common::create_malidrive_road_network(
+        "TwoRoadsWithTrafficSigns.xodr",
+        None,
+        Some("traffic_control_device_db_example.yaml"),
+    );
+    let book = road_network.traffic_sign_book();
+
+    let ss1 = book.get_traffic_sign(&SS1_ID.to_string()).expect("SS1 not found");
+    let ss1_deps = ss1.dependent_signs();
+    // In this example, there are no dependent signs defined.
+    assert!(ss1_deps.is_empty(), "Expected no dependent signs for SS1, got {:?}", ss1_deps);
+
+    let ss2 = book.get_traffic_sign(&SS2_ID.to_string()).expect("SS2 not found");
+    let ss2_deps = ss2.dependent_signs();
+    // In this example, there are no dependent signs defined.
+    assert!(ss2_deps.is_empty(), "Expected no dependent signs for SS2, got {:?}", ss2_deps);
+}

--- a/maliput/tests/traffic_sign_tests.rs
+++ b/maliput/tests/traffic_sign_tests.rs
@@ -204,10 +204,18 @@ fn traffic_sign_dependent_signs_test() {
     let ss1 = book.get_traffic_sign(&SS1_ID.to_string()).expect("SS1 not found");
     let ss1_deps = ss1.dependent_signs();
     // In this example, there are no dependent signs defined.
-    assert!(ss1_deps.is_empty(), "Expected no dependent signs for SS1, got {:?}", ss1_deps);
+    assert!(
+        ss1_deps.is_empty(),
+        "Expected no dependent signs for SS1, got {:?}",
+        ss1_deps
+    );
 
     let ss2 = book.get_traffic_sign(&SS2_ID.to_string()).expect("SS2 not found");
     let ss2_deps = ss2.dependent_signs();
     // In this example, there are no dependent signs defined.
-    assert!(ss2_deps.is_empty(), "Expected no dependent signs for SS2, got {:?}", ss2_deps);
+    assert!(
+        ss2_deps.is_empty(),
+        "Expected no dependent signs for SS2, got {:?}",
+        ss2_deps
+    );
 }


### PR DESCRIPTION
# 🎉 New feature

Closes #330 

## Summary
* API for TrafficSigns that have dependent TrafficSigns.
* API is currently **not** implemented and will always return an empty vector.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
