### PR TITLE
Bindings for `TrafficSign::dependent_signs`

### DIFF
--- a/maliput-sys/src/api/rules/mod.rs
+++ b/maliput-sys/src/api/rules/mod.rs
@@ -566,6 +566,7 @@ pub mod ffi {
         fn is_dynamic(self: &TrafficSign) -> bool;
         fn is_movable(self: &TrafficSign) -> bool;
         fn TrafficSign_related_lanes(sign: &TrafficSign) -> Vec<String>;
+        fn TrafficSign_dependent_signs(sign: &TrafficSign) -> Vec<String>;
         fn TrafficSign_bounding_box(sign: &TrafficSign) -> UniquePtr<BoundingBox>;
         fn TrafficSign_value(sign: &TrafficSign) -> TrafficSignValueData;
         fn TrafficSign_properties(sign: &TrafficSign) -> Vec<StringPair>;

--- a/maliput-sys/src/api/rules/rules.cc
+++ b/maliput-sys/src/api/rules/rules.cc
@@ -629,6 +629,14 @@ rust::Vec<rust::String> TrafficSign_related_lanes(const TrafficSign& sign) {
   return lane_ids;
 }
 
+rust::Vec<rust::String> TrafficSign_dependent_signs(const TrafficSign& sign) {
+  rust::Vec<rust::String> dependent_sign_ids;
+  for (const auto& sign_id : sign.dependent_signs()) {
+    dependent_sign_ids.push_back(sign_id.string());
+  }
+  return dependent_sign_ids;
+}
+
 std::unique_ptr<maliput::math::BoundingBox> TrafficSign_bounding_box(const TrafficSign& sign) {
   return std::make_unique<maliput::math::BoundingBox>(sign.bounding_box());
 }

--- a/maliput-sys/src/api/rules/rules.h
+++ b/maliput-sys/src/api/rules/rules.h
@@ -204,6 +204,7 @@ std::unique_ptr<maliput::api::InertialPosition> TrafficSign_position_road_networ
 std::unique_ptr<maliput::api::Rotation> TrafficSign_orientation_road_network(const TrafficSign& sign);
 std::unique_ptr<StringWrapper> TrafficSign_message(const TrafficSign& sign);
 rust::Vec<rust::String> TrafficSign_related_lanes(const TrafficSign& sign);
+rust::Vec<rust::String> TrafficSign_dependent_signs(const TrafficSign& sign);
 std::unique_ptr<maliput::math::BoundingBox> TrafficSign_bounding_box(const TrafficSign& sign);
 TrafficSignValueData TrafficSign_value(const TrafficSign& sign);
 rust::Vec<StringPair> TrafficSign_properties(const TrafficSign& sign);

--- a/maliput/src/api/rules/mod.rs
+++ b/maliput/src/api/rules/mod.rs
@@ -3334,7 +3334,7 @@ impl<'a> TrafficSign<'a> {
     /// Returns the [TrafficSign]s' IDs that depend on this sign, if any.
     /// For example, a "Stop" sign may have an associated "All way" sign.
     pub fn dependent_signs(&self) -> Vec<String> {
-        vec![]
+        maliput_sys::api::rules::ffi::TrafficSign_dependent_signs(self.traffic_sign)
     }
 }
 

--- a/maliput/tests/traffic_sign_tests.rs
+++ b/maliput/tests/traffic_sign_tests.rs
@@ -53,6 +53,14 @@ mod common;
 
 const SS1_ID: &str = "SS1";
 const SS2_ID: &str = "SS2";
+const ST1_ID: &str = "ST1";
+const AW1_ID: &str = "AW1";
+const ST2_ID: &str = "ST2";
+const AW2_ID: &str = "AW2";
+const ST3_ID: &str = "ST3";
+const AW3_ID: &str = "AW3";
+const ST4_ID: &str = "ST4";
+const AW4_ID: &str = "AW4";
 
 #[test]
 fn traffic_sign_book_api() {
@@ -194,28 +202,31 @@ fn traffic_sign_book_find_by_type_test() {
 
 #[test]
 fn traffic_sign_dependent_signs_test() {
-    let road_network = common::create_malidrive_road_network(
-        "TwoRoadsWithTrafficSigns.xodr",
-        None,
-        Some("traffic_control_device_db_example.yaml"),
-    );
+    let road_network =
+        common::create_malidrive_road_network("XCrossStopAllWay.xodr", None, Some("testing_database.yaml"));
     let book = road_network.traffic_sign_book();
 
-    let ss1 = book.get_traffic_sign(&SS1_ID.to_string()).expect("SS1 not found");
-    let ss1_deps = ss1.dependent_signs();
-    // In this example, there are no dependent signs defined.
-    assert!(
-        ss1_deps.is_empty(),
-        "Expected no dependent signs for SS1, got {:?}",
-        ss1_deps
-    );
+    let expected_dependencies = [(ST1_ID, AW1_ID), (ST2_ID, AW2_ID), (ST3_ID, AW3_ID), (ST4_ID, AW4_ID)];
 
-    let ss2 = book.get_traffic_sign(&SS2_ID.to_string()).expect("SS2 not found");
-    let ss2_deps = ss2.dependent_signs();
-    // In this example, there are no dependent signs defined.
-    assert!(
-        ss2_deps.is_empty(),
-        "Expected no dependent signs for SS2, got {:?}",
-        ss2_deps
-    );
+    for (stop_id, all_way_id) in expected_dependencies {
+        let stop_sign = book
+            .get_traffic_sign(&stop_id.to_string())
+            .unwrap_or_else(|| panic!("{} not found", stop_id));
+        let dependent_signs = stop_sign.dependent_signs();
+        assert_eq!(
+            dependent_signs,
+            vec![all_way_id.to_string()],
+            "Unexpected dependent_signs for {}",
+            stop_id
+        );
+
+        let all_way_sign = book
+            .get_traffic_sign(&all_way_id.to_string())
+            .unwrap_or_else(|| panic!("{} not found", all_way_id));
+        assert!(
+            all_way_sign.dependent_signs().is_empty(),
+            "Expected no dependent signs for {}",
+            all_way_id
+        );
+    }
 }


### PR DESCRIPTION
# 🎉 New feature

Closes #336 

## Summary
* Bindings for `TrafficSign::dependent_signs`.
* Implement `TrafficSign::dependent_signs` API.
* Add tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
